### PR TITLE
EP-1472

### DIFF
--- a/docs/api/v2/endpoints/apiv2MenuEndpoints.yml
+++ b/docs/api/v2/endpoints/apiv2MenuEndpoints.yml
@@ -13,6 +13,8 @@ paths:
     get:
       tags:
         - menu
+      security:
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -20,14 +22,8 @@ paths:
           required: true
           schema:
             type: string
-        - name: Authorization
-          in: header
-          description: Token de autenticación.
-          required: true
-          schema:
-            type: string
       responses:
-        200:
+        '200':
           description: success 
           content:
             application/json:
@@ -36,16 +32,12 @@ paths:
     post:
       tags:
         - menu
+      security:
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
           description: Corresponde al identificador interno que posea cada marca para su respectivo menú.
-          required: true
-          schema:
-            type: string
-        - name: Authorization
-          in: header
-          description: Token de autenticación.
           required: true
           schema:
             type: string
@@ -56,7 +48,7 @@ paths:
             schema:
               $ref: '#/components/schemas/menuParamsPost'
       responses:
-        200:
+        '200':
           description: success 
           content:
             application/json:
@@ -65,16 +57,12 @@ paths:
     patch:
       tags:
         - menu
+      security:
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
           description: Corresponde al identificador interno que posea cada marca para su respectivo menú.
-          required: true
-          schema:
-            type: string
-        - name: Authorization
-          in: header
-          description: Token de autenticación.
           required: true
           schema:
             type: string
@@ -85,7 +73,7 @@ paths:
             schema:
               $ref: '#/components/schemas/menuParamsPost'
       responses:
-        200:
+        '200':
           description: success 
           content:
             application/json:
@@ -94,16 +82,12 @@ paths:
     put:
       tags:
         - menu
+      security:
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
           description: Corresponde al identificador interno que posea cada marca para su respectivo menú.
-          required: true
-          schema:
-            type: string
-        - name: Authorization
-          in: header
-          description: Token de autenticación.
           required: true
           schema:
             type: string
@@ -114,7 +98,7 @@ paths:
             schema:
               $ref: '#/components/schemas/menuParams'
       responses:
-        200:
+        '200':
           description: Order injected successfully
           content:
             application/json:
@@ -123,16 +107,12 @@ paths:
     head:
       tags:
         - menu
+      security:
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
           description: Corresponde al identificador interno que posea cada marca para su respectivo menú.
-          required: true
-          schema:
-            type: string
-        - name: Authorization
-          in: header
-          description: Token de autenticación.
           required: true
           schema:
             type: string
@@ -146,6 +126,11 @@ paths:
         '422':
           description: error
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     menuParams:
       type: object
@@ -413,3 +398,6 @@ components:
           description: Las opciones.
           items:
             $ref: '#/components/schemas/option'
+  responses:
+    UnauthorizedError:
+      description: Access token is missing or invalid

--- a/docs/api/v2/endpoints/apiv2MenuEndpoints.yml
+++ b/docs/api/v2/endpoints/apiv2MenuEndpoints.yml
@@ -5,11 +5,14 @@ info:
 servers:
   - url: https://api.getjusto.com/api/v2
     description: Production server
+tags:
+  - name: menu
+    description: Todo lo relacionado a operar con menús
 paths:
   /menu/{id}:
     get:
-      summary: Obtener un menú
-      description: Usa este método para obtener un menú con sus respectivos items
+      tags:
+        - menu
       parameters:
         - name: id
           in: path
@@ -31,8 +34,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/menuResultGet'
     post:
-      summary: Crear un menú
-      description: Usa este método para crear un menú
+      tags:
+        - menu
       parameters:
         - name: id
           in: path
@@ -60,8 +63,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/menuResult'
     patch:
-      summary: Actualizar parcialmente un menú
-      description: Usa este método para actualizar un menú
+      tags:
+        - menu
       parameters:
         - name: id
           in: path
@@ -89,8 +92,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/menuResult'
     put:
-      summary: Actualizar un menú
-      description: Usa este método para actualizar un menú
+      tags:
+        - menu
       parameters:
         - name: id
           in: path
@@ -117,7 +120,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/menuResult'
-
+    head:
+      tags:
+        - menu
+      parameters:
+        - name: id
+          in: path
+          description: Corresponde al identificador interno que posea cada marca para su respectivo menú.
+          required: true
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          description: Token de autenticación.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: success 
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/menuResult'
+        '422':
+          description: error
 components:
   schemas:
     menuParams:

--- a/docs/api/v2/endpoints/get.mdx
+++ b/docs/api/v2/endpoints/get.mdx
@@ -1,3 +1,5 @@
 ---
+title: "Obtener un menú"
+description: "Usa este método para obtener un menú con sus respectivos items"
 openapi: get /menu/{id}
 ---

--- a/docs/api/v2/endpoints/head.mdx
+++ b/docs/api/v2/endpoints/head.mdx
@@ -1,0 +1,5 @@
+---
+title: "Existe un menú"
+description: "Usa este recurso para saber si existe un determinado menú"
+openapi: head /menu/{id}
+---

--- a/docs/api/v2/endpoints/patch.mdx
+++ b/docs/api/v2/endpoints/patch.mdx
@@ -1,3 +1,5 @@
 ---
+title: "Actualizar parcialmente un menú"
+description: "Usa este método para actualizar un menú"
 openapi: patch /menu/{id}
 ---

--- a/docs/api/v2/endpoints/post.mdx
+++ b/docs/api/v2/endpoints/post.mdx
@@ -1,3 +1,5 @@
 ---
+title: "Crear un menú"
+description: "Usa este recurso para crear un menú"
 openapi: post /menu/{id}
 ---

--- a/docs/api/v2/endpoints/put.mdx
+++ b/docs/api/v2/endpoints/put.mdx
@@ -1,3 +1,5 @@
 ---
+title: "Actualizar un menú"
+description: "Usa este recurso para actualizar un menú"
 openapi: put /menu/{id}
 ---

--- a/mint.json
+++ b/mint.json
@@ -93,10 +93,11 @@
         {
           "group": "Endpoints",
           "pages": [
+            "docs/api/v2/endpoints/head",
+            "docs/api/v2/endpoints/get",
             "docs/api/v2/endpoints/post",
             "docs/api/v2/endpoints/put",
-            "docs/api/v2/endpoints/patch",
-            "docs/api/v2/endpoints/get"
+            "docs/api/v2/endpoints/patch"
           ]
         }
       ]


### PR DESCRIPTION
## Propósito

Hacer que la documentación se pueda probar en linea al agregar el bearer en la parte de autorización.

Contexto:
- Sin este cambio, podías intentar probar la API pero tenías que colocar `bearer <apikey>`, por lo que generaba confusiones y al final no se sacaban partido a esta herramienta de documentación.
 

## Estrategia

Al agregar estas opciones (bearerAuth), obliga a quienes prueben la API puedan hacerlo solo colocando el apiKey

## ¿Cómo se debería revisar este PR?
- Solo confia en el proceso

## El PR corresponde a:

- [ ] Bug
- [ ] Feature
- [x] Deuda Técnica
- [ ] Vulnerabilidad

## Aseguramiento de la calidad (obligatorio)
- Se hicieron varias pruebas locales e incluso con datos de producción.

## Deuda técnica (opcional)
- N/A

## Aprendizaje (opcional)
- N/A


## Changelog
- Agregamos una configuración de autorización para que puedan probar desde la misma documentación de la API v2 los diferentes endpoint.