### PR TITLE
EP-2881: Documentar campos PUM en API de menú

### DIFF
--- a/docs/old/v2/endpoints/menu/apiv2MenuEndpoints.yml
+++ b/docs/old/v2/endpoints/menu/apiv2MenuEndpoints.yml
@@ -214,7 +214,14 @@ components:
           type: array
           description: Arreglo con las URLs de las imágenes de este producto. Puedes usar cualquier URL externa y se va a subir la imagen a los servidores de Justo. El tamaño máximo para las imagenes es de 10mb. Si es que quieres dejar el producto sin imágenes, puedes enviar un arreglo vacío.
           items:
-            type: string            
+            type: string
+        measurementUnit:
+          type: string
+          description: Unidad de medida del producto para el cálculo del Precio por Unidad de Medida (PUM) según DS N° 38/2024.
+          enum: ['kg', 'gr', 'und', 'ltr', 'ml']
+        measurementValue:
+          type: number
+          description: Valor numérico del contenido del producto en la unidad de medida indicada. Debe ser mayor o igual a 0.
 
     category:
       type: object


### PR DESCRIPTION
## Summary

- Agrega campos `measurementUnit` (enum: kg, gr, und, ltr, ml) y `measurementValue` (number >= 0) al schema de producto en la documentación OpenAPI del endpoint de menú V2
- Corresponde a los cambios implementados en EP-2870 (PR getjusto/justo-services#5773)

## Test plan

- [ ] Verificar que la documentación renderiza correctamente los nuevos campos en el schema de producto
- [ ] Confirmar que el enum y las descripciones coinciden con la implementación