### PR TITLE
Add ecommerce v3 API documentation

### DIFF
--- a/docs/ecommerce/adapters/menu-put-mcd-v1.mdx
+++ b/docs/ecommerce/adapters/menu-put-mcd-v1.mdx
@@ -1,0 +1,196 @@
+---
+title: Importar menú McDonald's
+description: "Adapter privado para importar menú McDonald's por local"
+openapi: put /adapters/menu-put-mcd-v1/stores/{storeId}
+noindex: true
+---
+
+<Warning>
+  Esta página no está listada en la navegación pública. Úsala solo para la integración McDonald's.
+</Warning>
+
+## Endpoint
+
+```http
+PUT /v3/adapters/menu-put-mcd-v1/stores/{storeId}
+```
+
+## Autenticación
+
+Envía el API key como bearer token.
+
+```http
+Authorization: Bearer <API_KEY>
+Content-Type: application/json
+```
+
+El API key debe tener permisos `admin` y acceso al local indicado en `storeId`. No envíes `auth_token` en el body.
+
+## Identificación
+
+Justo identifica las entidades de McDonald's concatenando el local con el identificador original:
+
+```txt
+{storeId}:{id_original_mcdonalds}
+```
+
+Ese `externalId` se usa para crear, actualizar o eliminar items sin mezclar datos entre locales. Si el identificador original contiene `:`, se conserva completo; Justo separa el local usando solo el primer `:` del `externalId`.
+
+Los campos originales que McDonald's necesita para trazabilidad quedan guardados en `metadata` sin el prefijo del local.
+
+```json
+{
+  "adapter": "mcd",
+  "type": "item",
+  "id": "CHO-26915-42065"
+}
+```
+
+## Flujo de integración
+
+```mermaid
+flowchart LR
+  McD["McDonald's\nMenú por local"] --> Adapter["Adapter\nmenu-put-mcd-v1"]
+  Store["storeId de la URL"] --> ExternalId["externalId\n{storeId}:{id_original}"]
+  Adapter --> ExternalId
+  ExternalId --> Menu["Menús y categorías\npor local"]
+  ExternalId --> Products["Productos\nvendidos separadamente"]
+  ExternalId --> Modifiers["Modificadores\ny opciones"]
+  Adapter --> Metadata["metadata\nIDs originales McDonald's"]
+  Metadata --> Webhooks["Webhooks y lecturas API\ncon trazabilidad externa"]
+  Products --> Outage["Adapter agotados\nproduct-outage-mcd-v1"]
+  Modifiers --> Outage
+```
+
+### Criterios de transformación
+
+| Caso McDonald's | Qué hace Justo |
+| --- | --- |
+| El catálogo viene por local, pero Justo normalmente modela menú por marca. | El adapter antepone `{storeId}:` a cada identificador y crea entidades independientes por local. |
+| Los SKUs pueden repetirse entre locales. | El `externalId` queda como `{storeId}:{id_original}`, evitando colisiones entre locales. |
+| El identificador original puede contener `:`. | Justo separa usando solo el primer `:`; el resto queda como parte del ID original. |
+| McDonald's necesita conservar sus IDs originales. | El `externalId` se usa para operar; el ID original sin prefijo queda en `metadata.id`. |
+| Las opciones de modificador vienen dentro de `items`. | El adapter detecta si el item es producto visible u opción de modificador según su uso en categorías y modifier groups. |
+| Hay cargas incrementales por local. | Los productos u opciones ausentes se eliminan solo dentro del menú/local importado, no en otros locales. |
+
+## Comportamiento
+
+- Cada local tiene su propio menú: `{storeId}:{app_menu_id}`.
+- Menús, productos, categorías, modificadores y opciones se identifican usando `externalId` con prefijo `{storeId}:`.
+- Los identificadores originales de McDonald's quedan guardados sin prefijo dentro de `metadata`.
+- Si un producto u opción deja de venir en el payload, se elimina solo para el menú/local importado.
+- Las categorías quedan por local y se actualizan por `externalId`.
+- Los modifier options del catálogo McDonald's se reciben como `items` y el adapter los transforma a opciones de modificadores Justo.
+
+## Campos raíz
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `menus` | `array<Menu>` | Sí | Lista de menús a importar. Cada menú genera o actualiza un menú/precio Justo con `externalId = {storeId}:{app_menu_id}`. |
+| `categories` | `array<Category>` | Sí | Catálogo de categorías referenciables por los menús. Solo se importan las categorías usadas por cada menú. |
+| `items` | `array<Item>` | Sí | Catálogo completo de productos y opciones. Los items con `is_sold_separately: true` se importan como productos; los items referenciados por grupos de modificadores se importan como opciones. |
+| `modifier_groups` | `array<ModifierGroup>` | Sí | Grupos de modificadores. Solo se importan los grupos referenciados por productos vendidos separadamente. |
+| `display_options` | `DisplayOptions` | No | Opciones visuales del origen. Actualmente se aceptan pero no cambian el menú Justo. |
+
+## `menus[]`
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `app_menu_id` | `string` | Sí | Identificador del menú McDonald's. Se usa para construir `externalId = {storeId}:{app_menu_id}` y queda guardado sin prefijo en `metadata.id`. |
+| `menu_name` | `string` | Sí | Nombre del menú/precio Justo. |
+| `app_category_ids` | `array<string>` | Sí | Categorías que componen el menú. Define qué categorías, productos y modificadores entran en la carga. |
+
+## `categories[]`
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `app_category_id` | `string` | Sí | Identificador de la categoría McDonald's. Se usa para construir `externalId = {storeId}:{app_category_id}` y queda guardado sin prefijo en `metadata.id`. |
+| `category_name` | `string` | Sí | Nombre de la categoría Justo. |
+| `app_item_ids` | `array<string>` | Sí | Items contenidos en la categoría. Solo los items con `is_sold_separately: true` se convierten en productos visibles. |
+
+## `items[]`
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `app_item_id` | `string` | Sí | Identificador del item McDonald's. Se usa para construir `externalId = {storeId}:{app_item_id}` y queda guardado sin prefijo en `metadata.id`. |
+| `item_name` | `string` | Sí | Nombre del producto u opción. Se usa como `name` e `internalName` cuando aplica. |
+| `short_desc` | `string` | No | Descripción del producto Justo. En opciones de modificador se acepta, pero no se expone como descripción principal. |
+| `sold_info_intl` | `array<SoldInfo>` | No | Horarios de venta del origen. Actualmente se aceptan pero no se transforman a horarios Justo. |
+| `head_img` | `string` | No | URL de imagen. Si viene, se agrega como primera imagen del producto u opción. |
+| `price` | `number` | No | Precio del producto u opción. Si no viene, se usa `0`. |
+| `status` | `number` | No | Disponibilidad del origen. `1` se importa como disponible; cualquier otro valor se importa como no disponible. |
+| `is_sold_separately` | `boolean` | No | Si es `true`, el item puede convertirse en producto visible si está en una categoría del menú. Si es `false`, normalmente se usa como opción de modificador. |
+| `app_modifier_group_ids` | `array<string>` | No | Grupos de modificadores asociados al producto. Se convierten a `modifiersExternalIds` con prefijo `{storeId}:`. |
+
+## `items[].sold_info_intl[]`
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `time` | `array<TimeRange>` | No | Rangos horarios del origen. Se acepta, pero actualmente no modifica disponibilidad en Justo. |
+| `day` | `array<number>` | No | Días del origen. Se acepta sin transformación. |
+| `specialDay` | `array<unknown>` | No | Días especiales del origen. Se acepta sin transformación. |
+
+## `items[].sold_info_intl[].time[]`
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `begin` | `string` | No | Hora de inicio en formato `HH:mm`. |
+| `end` | `string` | No | Hora de término en formato `HH:mm`. |
+
+## `modifier_groups[]`
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `app_modifier_group_id` | `string` | Sí | Identificador del grupo McDonald's. Se usa para construir `externalId = {storeId}:{app_modifier_group_id}` y queda guardado sin prefijo en `metadata.id`. |
+| `modifier_group_name` | `string` | Sí | Nombre, nombre corto e internal name del modificador Justo. |
+| `is_required` | `number` | No | Define si el grupo es obligatorio. `1` se importa como obligatorio; cualquier otro valor se importa como opcional. |
+| `quantity_min_permitted` | `number` | No | Mínimo de opciones seleccionables. Si no viene, se usa `0`. |
+| `quantity_max_permitted` | `number` | No | Máximo de opciones seleccionables. Si no viene, se usa `0`. |
+| `buy_mode` | `number` | No | Modo de compra del origen. Se acepta pero actualmente no se transforma a un campo Justo. |
+| `app_mg_items` | `array<ModifierGroupItem>` | No | Opciones del grupo. Cada `app_item_id` debe existir en `items` para importarse como opción. |
+
+## `modifier_groups[].app_mg_items[]`
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `app_item_id` | `string` | Sí | Referencia a un item de `items`. Ese item se transforma en opción del modificador. |
+
+## `display_options`
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `disable_item_instructions` | `boolean` | No | Opción visual del origen. Actualmente se acepta pero no cambia el menú Justo. |
+
+## Transformación del menú
+
+| Origen McDonald's | Destino Justo |
+| --- | --- |
+| `menus[].app_menu_id` | `menu.externalId = {storeId}:{app_menu_id}` |
+| `menus[].app_menu_id` | `menu.metadata = {adapter: "mcd", type: "menu", id: app_menu_id}` |
+| `menus[].menu_name` | `menu.name` |
+| `categories[].app_category_id` | `category.externalId = {storeId}:{app_category_id}` |
+| `categories[].app_category_id` | `category.metadata = {adapter: "mcd", type: "category", id: app_category_id}` |
+| `categories[].category_name` | `category.name` |
+| `items[].app_item_id` con `is_sold_separately: true` | `product.externalId = {storeId}:{app_item_id}` |
+| `items[].app_item_id` con `is_sold_separately: true` | `product.metadata = {adapter: "mcd", type: "item", id: app_item_id}` |
+| `items[].app_item_id` usado como opción | `option.externalId = {storeId}:{app_item_id}` |
+| `items[].app_item_id` usado como opción | `option.metadata = {adapter: "mcd", type: "item", id: app_item_id}` |
+| `items[].short_desc` | `product.description` |
+| `items[].price` | Precio del producto u opción en el menú importado |
+| `items[].price` | `priceMetadata = {adapter: "mcd", type: "itemPrice", id: app_item_id}` |
+| `items[].status` | `available = status === 1` |
+| `items[].head_img` | Primera imagen del producto u opción |
+| `items[].app_modifier_group_ids` | Modificadores del producto |
+| `modifier_groups[].app_modifier_group_id` | `modifier.externalId = {storeId}:{app_modifier_group_id}` |
+| `modifier_groups[].app_modifier_group_id` | `modifier.metadata = {adapter: "mcd", type: "modifier_group", id: app_modifier_group_id}` |
+| `modifier_groups[].app_mg_items[].app_item_id` | Opciones del modificador |
+
+## Ejemplo
+
+```bash
+curl -X PUT \
+  "https://api.service.getjusto.com/v3/adapters/menu-put-mcd-v1/stores/{storeId}" \
+  -H "Authorization: Bearer <API_KEY>" \
+  -H "Content-Type: application/json" \
+  --data-binary @catalogo-local.json
+```

--- a/docs/ecommerce/adapters/product-outage-mcd-v1.mdx
+++ b/docs/ecommerce/adapters/product-outage-mcd-v1.mdx
@@ -1,0 +1,151 @@
+---
+title: Agotar productos McDonald's
+description: "Adapter privado para agotar productos y opciones McDonald's por local"
+openapi: post /adapters/product-outage-mcd-v1/stores/{storeId}
+noindex: true
+---
+
+<Warning>
+  Esta página no está listada en la navegación pública. Úsala solo para la integración McDonald's.
+</Warning>
+
+## Endpoint
+
+```http
+POST /v3/adapters/product-outage-mcd-v1/stores/{storeId}
+```
+
+## Autenticación
+
+Envía el API key como bearer token.
+
+```http
+Authorization: Bearer <API_KEY>
+Content-Type: application/json
+```
+
+El API key debe tener permisos `admin` y acceso al local indicado en `storeId`. No envíes `auth_token` en el body.
+
+## Identificación
+
+Justo resuelve cada item concatenando el local con el identificador original:
+
+```txt
+{storeId}:{app_item_id}
+```
+
+Ese `externalId` permite agotar o liberar productos y opciones sin mezclar datos entre locales. Si el identificador original contiene `:`, se conserva completo; Justo separa el local usando solo el primer `:` del `externalId`.
+
+Los campos originales que McDonald's necesita para trazabilidad quedan guardados en `metadata` durante la importación de menú. El adapter de agotados usa esos `externalId` ya creados para ubicar productos u opciones.
+
+## Flujo de integración
+
+```mermaid
+flowchart LR
+  OutageFile["Outage McDonald's\napp_item_ids + status"] --> Adapter["Adapter\nproduct-outage-mcd-v1"]
+  Store["storeId de la URL"] --> ExternalId["externalId\n{storeId}:{app_item_id}"]
+  Adapter --> ExternalId
+  ExternalId --> Lookup["Buscar entidades Justo\npor externalId"]
+  Lookup --> Product["Producto"]
+  Lookup --> Option["Opción de modificador"]
+  Product --> OOS["Out of stock\nindefinido"]
+  Option --> OOS
+  OOS --> Response["Respuesta por item\nprocesados y errores parciales"]
+  Metadata["metadata creada por\nmenu-put-mcd-v1"] --> Lookup
+```
+
+### Criterios de transformación
+
+| Caso McDonald's | Qué hace Justo |
+| --- | --- |
+| El agotado viene por local. | El `storeId` de la URL se usa para resolver cada item como `{storeId}:{app_item_id}`. |
+| El mismo `app_item_id` puede existir en otro local. | Solo se modifica el producto u opción cuyo `externalId` empieza con el `storeId` recibido. |
+| El `app_item_id` puede contener `:`. | Justo separa usando solo el primer `:` del `externalId`; el ID original se mantiene completo. |
+| McDonald's manda opciones como si fueran productos. | El adapter busca tanto productos como opciones de modificador con el mismo `externalId`. |
+| `status: 2` significa agotado temporal, pero sin fecha final. | Justo crea un agotado indefinido. |
+| Pueden venir varios items en el mismo payload. | Se procesan todos; si alguno no existe, queda en `errors` y los demás siguen. |
+
+## Comportamiento
+
+- El cambio aplica solo al local indicado en `{storeId}`.
+- Cada item se resuelve como `externalId = {storeId}:{app_item_id}`.
+- `status: 2` marca los items como agotados indefinidamente.
+- `status: 1` marca los items como disponibles y elimina el agotado temporal.
+- La operación acepta múltiples items en una sola llamada.
+- Si un `app_item_id` corresponde a un producto Justo, se actualiza el producto.
+- Si un `app_item_id` corresponde a una opción de modificador Justo, se actualizan todas las opciones con ese `externalId`.
+- Si un item no existe en Justo, la respuesta lo incluye en `errors` y continúa procesando el resto.
+
+## Campos raíz
+
+| Campo | Tipo | Requerido | Uso |
+| --- | --- | --- | --- |
+| `app_item_ids` | `array<string>` | Sí | Lista de IDs originales McDonald's a actualizar. Se resuelven en Justo como `{storeId}:{app_item_id}`. |
+| `status` | `number` | Sí | Estado de disponibilidad. `2` significa agotado; `1` significa disponible. |
+
+## `status`
+
+| Valor | Resultado |
+| --- | --- |
+| `2` | Crea o actualiza un agotado temporal indefinido (`until: none`). |
+| `1` | Elimina el agotado temporal del producto u opción y lo deja disponible. |
+
+## Ejemplo para agotar
+
+```json
+{
+  "app_item_ids": [
+    "RAW-1000426",
+    "480 @ADSA-PE-PILOTO SP1-800240",
+    "CHO-26935-42159"
+  ],
+  "status": 2
+}
+```
+
+```bash
+curl -X POST \
+  "https://api.service.getjusto.com/v3/adapters/product-outage-mcd-v1/stores/{storeId}" \
+  -H "Authorization: Bearer <API_KEY>" \
+  -H "Content-Type: application/json" \
+  --data-binary @outage.json
+```
+
+## Respuesta
+
+```json
+{
+  "success": true,
+  "data": {
+    "adapter": "product-outage-mcd-v1",
+    "storeId": "vN2A6s5TasNM73zrg",
+    "status": 2,
+    "outOfStock": true,
+    "items": [
+      {
+        "appItemId": "CHO-26935-42159",
+        "externalId": "vN2A6s5TasNM73zrg:CHO-26935-42159",
+        "outOfStock": true,
+        "productIds": [],
+        "modifierOptionIds": ["abc123"],
+        "outOfStockItemIds": ["oos123"]
+      }
+    ],
+    "errors": []
+  }
+}
+```
+
+## Errores parciales
+
+Si un item no existe en Justo, se reporta en `errors`:
+
+```json
+{
+  "appItemId": "RAW-1000426",
+  "externalId": "vN2A6s5TasNM73zrg:RAW-1000426",
+  "message": "Item not found"
+}
+```
+
+Los errores parciales no detienen la operación completa. Los demás items válidos se procesan normalmente.

--- a/docs/ecommerce/endpoints/catalog/get-category.mdx
+++ b/docs/ecommerce/endpoints/catalog/get-category.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/categories/{categoryId}
+---

--- a/docs/ecommerce/endpoints/catalog/get-modifier-option.mdx
+++ b/docs/ecommerce/endpoints/catalog/get-modifier-option.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/modifier-options/{modifierOptionId}
+---

--- a/docs/ecommerce/endpoints/catalog/get-modifier.mdx
+++ b/docs/ecommerce/endpoints/catalog/get-modifier.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/modifiers/{modifierId}
+---

--- a/docs/ecommerce/endpoints/catalog/get-price.mdx
+++ b/docs/ecommerce/endpoints/catalog/get-price.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/prices/{priceId}
+---

--- a/docs/ecommerce/endpoints/catalog/get-product.mdx
+++ b/docs/ecommerce/endpoints/catalog/get-product.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/products/{productId}
+---

--- a/docs/ecommerce/endpoints/catalog/list-categories.mdx
+++ b/docs/ecommerce/endpoints/catalog/list-categories.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/categories
+---

--- a/docs/ecommerce/endpoints/catalog/list-modifier-options.mdx
+++ b/docs/ecommerce/endpoints/catalog/list-modifier-options.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/modifier-options
+---

--- a/docs/ecommerce/endpoints/catalog/list-modifiers.mdx
+++ b/docs/ecommerce/endpoints/catalog/list-modifiers.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/modifiers
+---

--- a/docs/ecommerce/endpoints/catalog/list-prices.mdx
+++ b/docs/ecommerce/endpoints/catalog/list-prices.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/prices
+---

--- a/docs/ecommerce/endpoints/catalog/list-products.mdx
+++ b/docs/ecommerce/endpoints/catalog/list-products.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/products
+---

--- a/docs/ecommerce/endpoints/catalog/update-category.mdx
+++ b/docs/ecommerce/endpoints/catalog/update-category.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /ecommerce/categories/{categoryId}
+---

--- a/docs/ecommerce/endpoints/catalog/update-modifier-option.mdx
+++ b/docs/ecommerce/endpoints/catalog/update-modifier-option.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /ecommerce/modifier-options/{modifierOptionId}
+---

--- a/docs/ecommerce/endpoints/catalog/update-modifier.mdx
+++ b/docs/ecommerce/endpoints/catalog/update-modifier.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /ecommerce/modifiers/{modifierId}
+---

--- a/docs/ecommerce/endpoints/catalog/update-price.mdx
+++ b/docs/ecommerce/endpoints/catalog/update-price.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /ecommerce/prices/{priceId}
+---

--- a/docs/ecommerce/endpoints/catalog/update-product.mdx
+++ b/docs/ecommerce/endpoints/catalog/update-product.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /ecommerce/products/{productId}
+---

--- a/docs/ecommerce/endpoints/menu/create-menu.mdx
+++ b/docs/ecommerce/endpoints/menu/create-menu.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /ecommerce/menu/{menuId}
+---

--- a/docs/ecommerce/endpoints/menu/get-menu.mdx
+++ b/docs/ecommerce/endpoints/menu/get-menu.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/menu/{menuId}
+---

--- a/docs/ecommerce/endpoints/menu/head-menu.mdx
+++ b/docs/ecommerce/endpoints/menu/head-menu.mdx
@@ -1,0 +1,3 @@
+---
+openapi: head /ecommerce/menu/{menuId}
+---

--- a/docs/ecommerce/endpoints/menu/list-menus.mdx
+++ b/docs/ecommerce/endpoints/menu/list-menus.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/menu
+---

--- a/docs/ecommerce/endpoints/menu/partially-update-menu.mdx
+++ b/docs/ecommerce/endpoints/menu/partially-update-menu.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /ecommerce/menu/{menuId}
+---

--- a/docs/ecommerce/endpoints/menu/update-menu.mdx
+++ b/docs/ecommerce/endpoints/menu/update-menu.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /ecommerce/menu/{menuId}
+---

--- a/docs/ecommerce/endpoints/orders/accept-order.mdx
+++ b/docs/ecommerce/endpoints/orders/accept-order.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /ecommerce/orders/{orderId}/accept
+---

--- a/docs/ecommerce/endpoints/orders/get-order.mdx
+++ b/docs/ecommerce/endpoints/orders/get-order.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/orders/{orderId}
+---

--- a/docs/ecommerce/endpoints/orders/list-orders.mdx
+++ b/docs/ecommerce/endpoints/orders/list-orders.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/orders
+---

--- a/docs/ecommerce/endpoints/orders/mark-order-prepared.mdx
+++ b/docs/ecommerce/endpoints/orders/mark-order-prepared.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /ecommerce/orders/{orderId}/preparation-ready
+---

--- a/docs/ecommerce/endpoints/orders/reject-order.mdx
+++ b/docs/ecommerce/endpoints/orders/reject-order.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /ecommerce/orders/{orderId}/reject
+---

--- a/docs/ecommerce/endpoints/products/set-product-out-of-stock.mdx
+++ b/docs/ecommerce/endpoints/products/set-product-out-of-stock.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /ecommerce/stores/{storeId}/products/{productId}/out-of-stock
+---

--- a/docs/ecommerce/endpoints/stores/get-store.mdx
+++ b/docs/ecommerce/endpoints/stores/get-store.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/stores/{storeId}
+---

--- a/docs/ecommerce/endpoints/stores/list-stores.mdx
+++ b/docs/ecommerce/endpoints/stores/list-stores.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /ecommerce/stores
+---

--- a/docs/ecommerce/endpoints/stores/temporary-close-store.mdx
+++ b/docs/ecommerce/endpoints/stores/temporary-close-store.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /ecommerce/stores/{storeId}/temporary-close
+---

--- a/docs/ecommerce/endpoints/stores/update-current-preparation-duration.mdx
+++ b/docs/ecommerce/endpoints/stores/update-current-preparation-duration.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /ecommerce/stores/{storeId}/current-preparation-duration
+---

--- a/docs/ecommerce/introduction.mdx
+++ b/docs/ecommerce/introduction.mdx
@@ -1,0 +1,8 @@
+---
+title: Ecommerce
+description: 'Endpoints para operar pedidos de ecommerce en Justo'
+---
+
+Usa esta sección para consultar y operar pedidos creados en el ecommerce de Justo.
+
+Los endpoints están disponibles bajo `https://api.service.getjusto.com/v3/api`.

--- a/docs/ecommerce/webhooks/orders/created.mdx
+++ b/docs/ecommerce/webhooks/orders/created.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /ecommerce.order.created
+---

--- a/docs/ecommerce/webhooks/orders/delivery-updated.mdx
+++ b/docs/ecommerce/webhooks/orders/delivery-updated.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /ecommerce.order.delivery.updated
+---
+
+Este webhook se envía cuando cambia el estado del despacho asociado a un pedido. Permite detectar asignaciones de driver, cambios de ETA ligados a la transición de estado y casos en que el despacho vuelve a un estado anterior.

--- a/docs/ecommerce/webhooks/orders/status-updated.mdx
+++ b/docs/ecommerce/webhooks/orders/status-updated.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /ecommerce.order.status.updated
+---

--- a/docs/main/openapi-webhooks.json
+++ b/docs/main/openapi-webhooks.json
@@ -173,6 +173,164 @@
         }
       }
     },
+    "/ecommerce.order.created": {
+      "post": {
+        "summary": "Pedido creado",
+        "requestBody": {
+          "description": "Webhook Payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "El tipo de webhook.",
+                    "type": "string",
+                    "enum": [
+                      "ecommerce.order.created"
+                    ],
+                    "const": "ecommerce.order.created"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "order": {
+                        "$ref": "#/components/schemas/apiOrder"
+                      }
+                    }
+                  },
+                  "websiteId": {
+                    "type": "string",
+                    "description": "ID de la marca."
+                  },
+                  "storeId": {
+                    "type": "string",
+                    "description": "ID del local."
+                  },
+                  "date": {
+                    "type": "string",
+                    "example": "2020-01-01T00:00:00.000Z",
+                    "format": "date-time",
+                    "description": "Fecha en que se generó el evento."
+                  },
+                  "eventId": {
+                    "type": "string",
+                    "description": "ID único del evento."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/ecommerce.order.status.updated": {
+      "post": {
+        "summary": "Estado de pedido actualizado",
+        "requestBody": {
+          "description": "Webhook Payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "El tipo de webhook.",
+                    "type": "string",
+                    "enum": [
+                      "ecommerce.order.status.updated"
+                    ],
+                    "const": "ecommerce.order.status.updated"
+                  },
+                  "data": {
+                    "$ref": "#/components/schemas/apiOrderStatusUpdatedWebhookData"
+                  },
+                  "websiteId": {
+                    "type": "string",
+                    "description": "ID de la marca."
+                  },
+                  "storeId": {
+                    "type": "string",
+                    "description": "ID del local."
+                  },
+                  "date": {
+                    "type": "string",
+                    "example": "2020-01-01T00:00:00.000Z",
+                    "format": "date-time",
+                    "description": "Fecha en que se generó el evento."
+                  },
+                  "eventId": {
+                    "type": "string",
+                    "description": "ID único del evento."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/ecommerce.order.delivery.updated": {
+      "post": {
+        "summary": "Despacho de pedido actualizado",
+        "requestBody": {
+          "description": "Webhook Payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "El tipo de webhook.",
+                    "type": "string",
+                    "enum": [
+                      "ecommerce.order.delivery.updated"
+                    ],
+                    "const": "ecommerce.order.delivery.updated"
+                  },
+                  "data": {
+                    "$ref": "#/components/schemas/apiOrderDeliveryUpdatedWebhookData"
+                  },
+                  "websiteId": {
+                    "type": "string",
+                    "description": "ID de la marca."
+                  },
+                  "storeId": {
+                    "type": "string",
+                    "description": "ID del local."
+                  },
+                  "date": {
+                    "type": "string",
+                    "example": "2020-01-01T00:00:00.000Z",
+                    "format": "date-time",
+                    "description": "Fecha en que se generó el evento."
+                  },
+                  "eventId": {
+                    "type": "string",
+                    "description": "ID único del evento."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/client.balance.syncClientBalance": {
       "post": {
         "summary": "Sincronización de saldo de cliente",
@@ -2585,16 +2743,7 @@
           "countryCode": {
             "type": "string",
             "description": "Código de país ISO 3166-1 alpha-2",
-            "example": "CL",
-            "enum": [
-              "CL",
-              "MX",
-              "PE",
-              "CO",
-              "EC",
-              "CR",
-              "AR"
-            ]
+            "example": "CL"
           },
           "createdAt": {
             "type": "string",
@@ -3368,7 +3517,8 @@
             "enum": [
               "product",
               "deliveryFee",
-              "serviceFee"
+              "serviceFee",
+              "billingItem"
             ],
             "description": "Tipo de item."
           },
@@ -3387,6 +3537,16 @@
             "type": "string",
             "example": "Juan",
             "description": "Nombre del cliente que agregó el item."
+          },
+          "addedByUserId": {
+            "type": "string",
+            "example": "a3W2hiuGGLi4eECFa",
+            "description": "El ID del garzón que digitó el item."
+          },
+          "addedByUserName": {
+            "type": "string",
+            "example": "Juan",
+            "description": "Nombre del garzón que digitó el item."
           },
           "eaterLabels": {
             "type": "array",
@@ -3962,13 +4122,13 @@
               "countryCode": {
                 "type": "string",
                 "enum": [
+                  "AR",
                   "CL",
-                  "MX",
-                  "PE",
                   "CO",
-                  "EC",
                   "CR",
-                  "AR"
+                  "EC",
+                  "MX",
+                  "PE"
                 ],
                 "example": "CL"
               },
@@ -4000,6 +4160,1450 @@
                 }
               }
             }
+          }
+        }
+      },
+      "apiMcdMenuPayload": {
+        "type": "object",
+        "description": "Payload de menú MCD compatible con menu-put-mcd-v1.",
+        "additionalProperties": true,
+        "required": [
+          "menus",
+          "categories",
+          "items",
+          "modifier_groups"
+        ],
+        "properties": {
+          "menus": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "modifier_groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "apiMcdMenuAdapterResult": {
+        "type": "object",
+        "description": "Resultado de la carga del menú MCD.",
+        "properties": {
+          "adapter": {
+            "type": "string",
+            "enum": [
+              "menu-put-mcd-v1"
+            ]
+          },
+          "storeId": {
+            "type": "string"
+          },
+          "menus": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "menuId": {
+                  "type": "string"
+                },
+                "method": {
+                  "type": "string",
+                  "enum": [
+                    "POST",
+                    "PUT"
+                  ]
+                },
+                "categories": {
+                  "type": "number"
+                },
+                "products": {
+                  "type": "number"
+                },
+                "modifiers": {
+                  "type": "number"
+                },
+                "options": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      },
+      "apiMcdProductOutagePayload": {
+        "type": "object",
+        "description": "Payload MCD para marcar productos u opciones como agotados o disponibles.",
+        "additionalProperties": false,
+        "required": [
+          "app_item_ids",
+          "status"
+        ],
+        "properties": {
+          "app_item_ids": {
+            "type": "array",
+            "description": "IDs originales de McDonald’s. Justo los resuelve como {storeId}:{app_item_id}.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "number",
+            "enum": [
+              1,
+              2
+            ],
+            "description": "1 marca los items como disponibles. 2 los marca como agotados indefinidamente."
+          }
+        }
+      },
+      "apiMcdProductOutageAdapterResult": {
+        "type": "object",
+        "description": "Resultado de la actualización de disponibilidad MCD.",
+        "properties": {
+          "adapter": {
+            "type": "string",
+            "enum": [
+              "product-outage-mcd-v1"
+            ]
+          },
+          "storeId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "number",
+            "enum": [
+              1,
+              2
+            ]
+          },
+          "outOfStock": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "appItemId": {
+                  "type": "string"
+                },
+                "externalId": {
+                  "type": "string"
+                },
+                "outOfStock": {
+                  "type": "boolean"
+                },
+                "productIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "modifierOptionIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "outOfStockItemIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "appItemId": {
+                  "type": "string"
+                },
+                "externalId": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "apiCategory": {
+        "type": "object",
+        "description": "Categoría de productos.",
+        "properties": {
+          "categoryId": {
+            "type": "string",
+            "description": "ID Justo de la categoría."
+          },
+          "importId": {
+            "type": "string",
+            "description": "ID de importación de la categoría."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre de la categoría."
+          },
+          "index": {
+            "type": "number",
+            "description": "Posición de ordenamiento."
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          }
+        }
+      },
+      "apiListingProduct": {
+        "type": "object",
+        "description": "Producto del catálogo.",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "description": "ID Justo del producto."
+          },
+          "importId": {
+            "type": "string",
+            "description": "ID de importación del producto."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del producto."
+          },
+          "internalName": {
+            "type": "string",
+            "description": "Nombre interno del producto."
+          },
+          "description": {
+            "type": "string",
+            "description": "Descripción visible del producto."
+          },
+          "url": {
+            "type": "string",
+            "description": "URL pública del producto."
+          },
+          "partialUrl": {
+            "type": "string",
+            "description": "Path público del producto."
+          },
+          "categoriesNames": {
+            "type": "array",
+            "description": "Nombres de categorías asociadas.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "categoriesIds": {
+            "type": "array",
+            "description": "IDs de categorías asociadas.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "modifiersIds": {
+            "type": "array",
+            "description": "IDs de modificadores asociados.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          },
+          "images": {
+            "type": "array",
+            "description": "URLs de imágenes del producto.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "menus": {
+            "type": "array",
+            "description": "Precio y disponibilidad por precio/menú.",
+            "items": {
+              "type": "object",
+              "description": "Precio y disponibilidad del item para un precio/menú.",
+              "properties": {
+                "menuId": {
+                  "type": "string",
+                  "description": "ID Justo del precio/menú."
+                },
+                "price": {
+                  "type": "number",
+                  "description": "Precio configurado para este precio/menú."
+                },
+                "basePrice": {
+                  "type": "number",
+                  "description": "Precio base configurado para este precio/menú."
+                },
+                "discount": {
+                  "type": "number",
+                  "description": "Descuento principal configurado."
+                },
+                "discounts": {
+                  "type": "array",
+                  "description": "Descuentos configurados.",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "available": {
+                  "type": "boolean",
+                  "description": "Indica si el item está disponible."
+                },
+                "externalId": {
+                  "type": "string",
+                  "description": "ID externo efectivo para este precio/menú, si fue reemplazado."
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Metadata del precio/disponibilidad escrita por API v3.",
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "apiListingModifier": {
+        "type": "object",
+        "description": "Modificador del catálogo.",
+        "properties": {
+          "modifierId": {
+            "type": "string",
+            "description": "ID Justo del modificador."
+          },
+          "importId": {
+            "type": "string",
+            "description": "ID de importación del modificador."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del modificador."
+          },
+          "description": {
+            "type": "string",
+            "description": "Descripción del modificador."
+          },
+          "shortName": {
+            "type": "string",
+            "description": "Nombre corto del modificador."
+          },
+          "internalName": {
+            "type": "string",
+            "description": "Nombre interno del modificador."
+          },
+          "min": {
+            "type": "number",
+            "description": "Cantidad mínima de opciones."
+          },
+          "max": {
+            "type": "number",
+            "description": "Cantidad máxima de opciones."
+          },
+          "optional": {
+            "type": "boolean",
+            "description": "Indica si el modificador es opcional."
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          },
+          "optionIds": {
+            "type": "array",
+            "description": "IDs de opciones asociadas.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "options": {
+            "type": "array",
+            "description": "Opciones asociadas al modificador.",
+            "items": {
+              "$ref": "#/components/schemas/apiModifierOption"
+            }
+          }
+        }
+      },
+      "apiModifierOption": {
+        "type": "object",
+        "description": "Opción de modificador.",
+        "properties": {
+          "optionId": {
+            "type": "string",
+            "description": "ID Justo de la opción."
+          },
+          "importId": {
+            "type": "string",
+            "description": "ID de importación de la opción."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre de la opción."
+          },
+          "internalName": {
+            "type": "string",
+            "description": "Nombre interno de la opción."
+          },
+          "max": {
+            "type": "number",
+            "description": "Cantidad máxima seleccionable."
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          },
+          "menus": {
+            "type": "array",
+            "description": "Precio y disponibilidad por precio/menú.",
+            "items": {
+              "type": "object",
+              "description": "Precio y disponibilidad del item para un precio/menú.",
+              "properties": {
+                "menuId": {
+                  "type": "string",
+                  "description": "ID Justo del precio/menú."
+                },
+                "price": {
+                  "type": "number",
+                  "description": "Precio configurado para este precio/menú."
+                },
+                "basePrice": {
+                  "type": "number",
+                  "description": "Precio base configurado para este precio/menú."
+                },
+                "discount": {
+                  "type": "number",
+                  "description": "Descuento principal configurado."
+                },
+                "discounts": {
+                  "type": "array",
+                  "description": "Descuentos configurados.",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "available": {
+                  "type": "boolean",
+                  "description": "Indica si el item está disponible."
+                },
+                "externalId": {
+                  "type": "string",
+                  "description": "ID externo efectivo para este precio/menú, si fue reemplazado."
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Metadata del precio/disponibilidad escrita por API v3.",
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "apiPrice": {
+        "type": "object",
+        "description": "Precio/menú interno de Justo.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID Justo del precio."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del precio."
+          },
+          "priority": {
+            "type": "number",
+            "description": "Prioridad de aplicación."
+          },
+          "storesIds": {
+            "type": "array",
+            "description": "Locales asociados.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "channels": {
+            "type": "array",
+            "description": "Canales asociados.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "daysBefore": {
+            "type": "number",
+            "description": "Días de anticipación permitidos."
+          },
+          "schedule": {
+            "type": "object",
+            "description": "Horario de disponibilidad del precio.",
+            "additionalProperties": true
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          }
+        }
+      },
+      "apiMenuV22Payload": {
+        "type": "object",
+        "description": "Payload de menú compatible con API v2.2. Incluye menu, products, options, modifiers y categories. En API v3 los objetos menu, products, options, modifiers y categories aceptan metadata. Products y options aceptan priceMetadata para guardar metadata del precio/disponibilidad del menú.",
+        "additionalProperties": true
+      },
+      "apiMenuV22MutationResult": {
+        "type": "object",
+        "description": "Resultado de una escritura de menú compatible con API v2.2.",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "description": "Errores no bloqueantes encontrados al procesar productos u opciones.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "apiOrder": {
+        "type": "object",
+        "description": "Pedido de ecommerce.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID del pedido.",
+            "example": "ord-123"
+          },
+          "orderStatus": {
+            "type": "string",
+            "description": "Estado operacional del pedido.",
+            "enum": [
+              "pending",
+              "waiting",
+              "preparing",
+              "delivering",
+              "done",
+              "cancelled"
+            ]
+          },
+          "paymentStatus": {
+            "type": "string",
+            "description": "Estado del pago del pedido.",
+            "enum": [
+              "pending",
+              "done",
+              "error",
+              "blocked",
+              "inReview",
+              "waitingForAdditionalPayment"
+            ]
+          },
+          "isScheduled": {
+            "type": "boolean",
+            "description": "Indica si el pedido es programado."
+          },
+          "isConfirmed": {
+            "type": "boolean",
+            "description": "Indica si el pedido programado fue confirmado."
+          },
+          "websiteId": {
+            "type": "string",
+            "description": "ID de la marca."
+          },
+          "storeId": {
+            "type": "string",
+            "description": "ID del local."
+          },
+          "code": {
+            "type": "string",
+            "description": "Código único del pedido en Justo.",
+            "example": "123"
+          },
+          "fullCode": {
+            "type": "string",
+            "description": "Código del pedido con el correlativo diario de la marca.",
+            "example": "C#123"
+          },
+          "userId": {
+            "type": "string",
+            "description": "ID del usuario que creó el pedido."
+          },
+          "createdAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha de creación del pedido."
+          },
+          "address": {
+            "$ref": "#/components/schemas/apiOrderAddress"
+          },
+          "menuId": {
+            "type": "string",
+            "description": "ID del menú desde el que se creó el pedido."
+          },
+          "deliveryType": {
+            "type": "string",
+            "description": "Tipo de entrega del pedido.",
+            "enum": [
+              "delivery",
+              "go",
+              "serve"
+            ]
+          },
+          "deliverAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha en que el pedido debe ser entregado o retirado."
+          },
+          "timeText": {
+            "type": "string",
+            "description": "Texto legible con la ventana estimada de entrega."
+          },
+          "paymentType": {
+            "type": "string",
+            "description": "Medio de pago seleccionado."
+          },
+          "paymentTypeLabel": {
+            "type": "string",
+            "description": "Nombre legible del medio de pago."
+          },
+          "paymentTypeIsIntegration": {
+            "type": "boolean",
+            "description": "Indica si el medio de pago viene de una integración."
+          },
+          "tipAmount": {
+            "type": "number",
+            "description": "Monto de propina."
+          },
+          "amountToPay": {
+            "type": "number",
+            "description": "Monto total a pagar por el cliente, incluyendo propina."
+          },
+          "deliveryFee": {
+            "type": "number",
+            "description": "Precio del despacho cobrado al cliente."
+          },
+          "serviceFee": {
+            "type": "number",
+            "description": "Cargo de servicio cobrado al cliente."
+          },
+          "itemsPrice": {
+            "type": "number",
+            "description": "Precio de los productos, sin propina ni despacho."
+          },
+          "totalPrice": {
+            "type": "number",
+            "description": "Monto del pedido sin propina."
+          },
+          "totalDiscount": {
+            "type": "number",
+            "description": "Monto total descontado del pedido."
+          },
+          "expectedPreparationDuration": {
+            "type": "number",
+            "description": "Tiempo estimado de preparación en minutos."
+          },
+          "deliveryDuration": {
+            "type": "number",
+            "description": "Tiempo estimado de despacho en minutos."
+          },
+          "cashAmount": {
+            "type": "number",
+            "description": "Monto que el cliente declara pagar si el medio de pago es efectivo."
+          },
+          "source": {
+            "type": "string",
+            "description": "Origen del pedido."
+          },
+          "buyerName": {
+            "type": "string",
+            "description": "Nombre del cliente."
+          },
+          "phone": {
+            "type": "string",
+            "description": "Teléfono del cliente."
+          },
+          "email": {
+            "type": "string",
+            "description": "Email del cliente."
+          },
+          "couponId": {
+            "type": "string",
+            "description": "ID del cupón usado."
+          },
+          "couponName": {
+            "type": "string",
+            "description": "Nombre del cupón usado."
+          },
+          "couponCode": {
+            "type": "string",
+            "description": "Código del cupón usado."
+          },
+          "couponDiscount": {
+            "type": "number",
+            "description": "Monto descontado por cupón."
+          },
+          "flagColor": {
+            "type": "string",
+            "description": "Color de la bandera del pedido en POS."
+          },
+          "items": {
+            "type": "array",
+            "description": "Detalle de los productos vendidos en el pedido.",
+            "items": {
+              "$ref": "#/components/schemas/apiOrderItem"
+            }
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/apiOrderTransaction"
+          },
+          "deliveries": {
+            "type": "array",
+            "description": "Despachos asociados al pedido.",
+            "items": {
+              "$ref": "#/components/schemas/apiOrderDelivery"
+            }
+          },
+          "orderParams": {
+            "type": "object",
+            "description": "Parámetros adicionales del pedido.",
+            "additionalProperties": true
+          },
+          "hasManagedDelivery": {
+            "type": "boolean",
+            "description": "Indica si el despacho es gestionado por Justo."
+          },
+          "gift": {
+            "type": "object",
+            "description": "Información de regalo, si el pedido fue marcado como regalo.",
+            "additionalProperties": true
+          },
+          "billing": {
+            "type": "object",
+            "description": "Información de facturación del cliente.",
+            "additionalProperties": true
+          },
+          "cancellationInfo": {
+            "type": "object",
+            "description": "Información de cancelación del pedido.",
+            "additionalProperties": true
+          },
+          "deliveryZoneName": {
+            "type": "string",
+            "description": "Nombre de la zona de despacho aplicada al pedido."
+          }
+        }
+      },
+      "apiOrderAddress": {
+        "type": "object",
+        "description": "Dirección de entrega del pedido.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID de la dirección."
+          },
+          "placeId": {
+            "type": "string",
+            "description": "ID del lugar asociado a la dirección."
+          },
+          "address": {
+            "type": "string",
+            "description": "Dirección principal en formato legacy.",
+            "example": "Av. Apoquindo 3000"
+          },
+          "addressLine2": {
+            "type": "string",
+            "description": "Departamento, oficina u otra información complementaria.",
+            "example": "Depto 1201"
+          },
+          "addressSecondary": {
+            "type": "string",
+            "description": "Comuna, ciudad o referencia secundaria de la dirección."
+          },
+          "location": {
+            "type": "object",
+            "description": "Coordenadas geográficas.",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "description": "Latitud.",
+                "example": -33.4489
+              },
+              "lng": {
+                "type": "number",
+                "description": "Longitud.",
+                "example": -70.6693
+              }
+            }
+          }
+        }
+      },
+      "apiOrderDelivery": {
+        "type": "object",
+        "description": "Información de un despacho asociado al pedido.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID del despacho."
+          },
+          "price": {
+            "type": "number",
+            "description": "Precio del despacho.",
+            "example": 2500
+          },
+          "status": {
+            "type": "string",
+            "description": "Estado del despacho.",
+            "enum": [
+              "active",
+              "canceled",
+              "cancelled",
+              "done",
+              "error",
+              "pending",
+              "scheduled",
+              "delivering",
+              "waiting",
+              "unconfirmed"
+            ]
+          },
+          "placeName": {
+            "type": "string",
+            "description": "Nombre del lugar de destino."
+          },
+          "isCash": {
+            "type": "boolean",
+            "description": "Indica si el despacho se paga en efectivo."
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Instrucciones para el despacho."
+          },
+          "fromLocation": {
+            "type": "object",
+            "description": "Coordenadas geográficas.",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "description": "Latitud.",
+                "example": -33.4489
+              },
+              "lng": {
+                "type": "number",
+                "description": "Longitud.",
+                "example": -70.6693
+              }
+            }
+          },
+          "toLocation": {
+            "type": "object",
+            "description": "Coordenadas geográficas.",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "description": "Latitud.",
+                "example": -33.4489
+              },
+              "lng": {
+                "type": "number",
+                "description": "Longitud.",
+                "example": -70.6693
+              }
+            }
+          },
+          "trackingURL": {
+            "type": "string",
+            "description": "URL de seguimiento del despacho."
+          },
+          "orderId": {
+            "type": "string",
+            "description": "ID del pedido asociado al despacho."
+          },
+          "activatesAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha en que se activa el despacho."
+          },
+          "createdAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha de creación del despacho."
+          },
+          "forDate": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha objetivo del despacho."
+          },
+          "pickupAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha de retiro del pedido."
+          },
+          "completedAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha en que se completó el despacho."
+          },
+          "canceledAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha de cancelación del despacho."
+          },
+          "deliveryExpectedAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha estimada de entrega."
+          },
+          "driverReceivedAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha en que el driver recibió el pedido, si aplica."
+          },
+          "driverInformation": {
+            "type": "object",
+            "description": "Información del driver asignado, si está disponible.",
+            "additionalProperties": true
+          },
+          "deliveryInformation": {
+            "type": "object",
+            "description": "Información adicional del despacho, si está disponible.",
+            "additionalProperties": true
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo del despacho, si existe."
+          },
+          "specialCode": {
+            "type": "string",
+            "description": "Código externo o especial del despacho, si existe."
+          }
+        }
+      },
+      "apiOrderDeliveryUpdatedWebhookData": {
+        "type": "object",
+        "description": "Datos del webhook de actualización de despacho de pedido.",
+        "properties": {
+          "order": {
+            "$ref": "#/components/schemas/apiOrder"
+          },
+          "delivery": {
+            "$ref": "#/components/schemas/apiOrderDelivery"
+          }
+        }
+      },
+      "apiOrderItem": {
+        "type": "object",
+        "description": "Producto vendido dentro del pedido.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID del item del pedido."
+          },
+          "product": {
+            "type": "object",
+            "description": "Producto asociado al item.",
+            "properties": {
+              "_id": {
+                "type": "string",
+                "description": "ID Justo del producto."
+              },
+              "name": {
+                "type": "string",
+                "description": "Nombre del producto.",
+                "example": "Hamburguesa"
+              },
+              "externalId": {
+                "type": "string",
+                "description": "ID externo del producto configurado por la marca."
+              },
+              "metadata": {
+                "type": "object",
+                "description": "Metadata del producto escrita por API v3.",
+                "additionalProperties": true
+              },
+              "priceMetadata": {
+                "type": "object",
+                "description": "Metadata del precio/disponibilidad escrita por API v3.",
+                "additionalProperties": true
+              }
+            }
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Precio unitario con descuento, sin incluir descuento de cupón.",
+            "example": 5990
+          },
+          "baseUnitPrice": {
+            "type": "number",
+            "description": "Precio unitario original antes de descuentos.",
+            "example": 5990
+          },
+          "productPrice": {
+            "type": "number",
+            "description": "Precio del producto con descuento.",
+            "example": 5990
+          },
+          "baseProductPrice": {
+            "type": "number",
+            "description": "Precio original del producto antes de descuentos.",
+            "example": 5990
+          },
+          "amount": {
+            "type": "number",
+            "description": "Cantidad de este producto en el pedido.",
+            "example": 2
+          },
+          "comment": {
+            "type": "string",
+            "description": "Instrucciones adicionales para este producto."
+          },
+          "description": {
+            "type": "string",
+            "description": "Resumen en texto de los modificadores e instrucciones del item.",
+            "example": "Bebida: Coca Zero - Comentario: \"Sin cebolla\""
+          },
+          "promotionId": {
+            "type": "string",
+            "description": "ID de la promoción aplicada al item."
+          },
+          "promotionDiscount": {
+            "type": "number",
+            "description": "Monto descontado por promoción en el item."
+          },
+          "promotionType": {
+            "type": "string",
+            "description": "Tipo de promoción aplicada al item."
+          },
+          "promotionLabel": {
+            "type": "string",
+            "description": "Etiqueta visible de la promoción aplicada al item."
+          },
+          "modifiers": {
+            "type": "array",
+            "description": "Modificadores seleccionados para el item.",
+            "items": {
+              "$ref": "#/components/schemas/apiOrderItemModifier"
+            }
+          }
+        }
+      },
+      "apiOrderItemModifier": {
+        "type": "object",
+        "description": "Modificador seleccionado para un item del pedido.",
+        "properties": {
+          "modifierId": {
+            "type": "string",
+            "description": "ID Justo del modificador."
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo del modificador configurado por la marca."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del modificador.",
+            "example": "Agregados"
+          },
+          "shortName": {
+            "type": "string",
+            "description": "Nombre corto del modificador."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del modificador escrita por API v3.",
+            "additionalProperties": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Resumen en texto de las opciones seleccionadas."
+          },
+          "countById": {
+            "type": "object",
+            "description": "Cantidad seleccionada por ID Justo de opción.",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "countByExternalId": {
+            "type": "object",
+            "description": "Cantidad seleccionada por ID externo de opción.",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "options": {
+            "type": "array",
+            "description": "Opciones seleccionadas para este modificador.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "optionId": {
+                  "type": "string",
+                  "description": "ID Justo de la opción."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Nombre de la opción.",
+                  "example": "Queso"
+                },
+                "price": {
+                  "type": "number",
+                  "description": "Precio pagado por la opción.",
+                  "example": 1000
+                },
+                "externalId": {
+                  "type": "string",
+                  "description": "ID externo de la opción configurado por la marca."
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Metadata de la opción escrita por API v3.",
+                  "additionalProperties": true
+                },
+                "priceMetadata": {
+                  "type": "object",
+                  "description": "Metadata del precio/disponibilidad escrita por API v3.",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "apiOrderStatusUpdatedWebhookData": {
+        "type": "object",
+        "description": "Datos del webhook de cambio de estado de pedido.",
+        "properties": {
+          "order": {
+            "$ref": "#/components/schemas/apiOrder"
+          },
+          "previousOrderStatus": {
+            "type": "string",
+            "description": "Estado anterior del pedido.",
+            "enum": [
+              "pending",
+              "waiting",
+              "preparing",
+              "delivering",
+              "done",
+              "cancelled"
+            ]
+          },
+          "newOrderStatus": {
+            "type": "string",
+            "description": "Nuevo estado del pedido.",
+            "enum": [
+              "pending",
+              "waiting",
+              "preparing",
+              "delivering",
+              "done",
+              "cancelled"
+            ]
+          }
+        }
+      },
+      "apiOrderTransaction": {
+        "type": "object",
+        "description": "Transacción de pago asociada al pedido.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID de la transacción."
+          },
+          "totalPrice": {
+            "type": "number",
+            "description": "Monto total de la transacción."
+          },
+          "paymentType": {
+            "type": "string",
+            "description": "Medio de pago usado en la transacción."
+          },
+          "cardType": {
+            "type": "string",
+            "description": "Tipo de tarjeta usada, si aplica."
+          },
+          "cardLast4": {
+            "type": "string",
+            "description": "Últimos cuatro dígitos de la tarjeta, si aplica."
+          },
+          "status": {
+            "type": "string",
+            "description": "Estado de la transacción."
+          }
+        }
+      },
+      "apiProductOutOfStock": {
+        "type": "object",
+        "description": "Estado de disponibilidad de un producto en un local.",
+        "properties": {
+          "storeId": {
+            "type": "string",
+            "description": "ID Justo del local."
+          },
+          "productId": {
+            "type": "string",
+            "description": "ID Justo del producto."
+          },
+          "productExternalId": {
+            "type": "string",
+            "description": "ID externo del producto configurado por la marca."
+          },
+          "outOfStock": {
+            "type": "boolean",
+            "description": "Indica si el producto quedó marcado como agotado en el local."
+          },
+          "outOfStockItemId": {
+            "type": "string",
+            "description": "ID del registro de producto agotado creado por Justo."
+          },
+          "until": {
+            "type": "string",
+            "enum": [
+              "none",
+              "tomorrow"
+            ],
+            "description": "Duración predefinida del bloqueo de stock."
+          },
+          "untilDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Fecha hasta la que el producto permanecerá agotado."
+          },
+          "stock": {
+            "type": "number",
+            "description": "Stock disponible configurado para el producto."
+          }
+        }
+      },
+      "apiStore": {
+        "type": "object",
+        "description": "Local de una marca.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID Justo del local."
+          },
+          "websiteId": {
+            "type": "string",
+            "description": "ID de la marca a la que pertenece el local."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del local.",
+            "example": "Providencia"
+          },
+          "acceptDelivery": {
+            "type": "boolean",
+            "description": "Indica si el local acepta pedidos con despacho."
+          },
+          "acceptServe": {
+            "type": "boolean",
+            "description": "Indica si el local acepta pedidos para servir en mesa."
+          },
+          "acceptGo": {
+            "type": "boolean",
+            "description": "Indica si el local acepta pedidos para retiro."
+          },
+          "currentPreparationDuration": {
+            "type": "number",
+            "description": "Tiempo actual de preparación en minutos."
+          },
+          "currentDeliveryDuration": {
+            "type": "number",
+            "description": "Tiempo actual estimado de despacho en minutos."
+          },
+          "phone": {
+            "type": "string",
+            "description": "Teléfono del local."
+          },
+          "address": {
+            "$ref": "#/components/schemas/apiStoreAddress"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo del local configurado por la marca."
+          },
+          "schedule": {
+            "$ref": "#/components/schemas/apiStoreSchedule"
+          }
+        }
+      },
+      "apiStoreAddress": {
+        "type": "object",
+        "description": "Dirección del local.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID de la dirección."
+          },
+          "placeId": {
+            "type": "string",
+            "description": "ID del lugar asociado a la dirección."
+          },
+          "address": {
+            "type": "string",
+            "description": "Dirección principal en formato legacy.",
+            "example": "Av. Apoquindo 3000"
+          },
+          "addressLine2": {
+            "type": "string",
+            "description": "Departamento, oficina u otra información complementaria."
+          },
+          "addressSecondary": {
+            "type": "string",
+            "description": "Comuna, ciudad o referencia secundaria de la dirección."
+          },
+          "streetAddress": {
+            "type": "string",
+            "description": "Calle y número normalizados."
+          },
+          "extendedAddress": {
+            "type": "string",
+            "description": "Información complementaria normalizada."
+          },
+          "locality": {
+            "type": "string",
+            "description": "Comuna o localidad."
+          },
+          "region": {
+            "type": "string",
+            "description": "Región o estado."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Código postal."
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "Código de país ISO 3166-1 alpha-2."
+          },
+          "countryName": {
+            "type": "string",
+            "description": "Nombre del país."
+          },
+          "location": {
+            "type": "object",
+            "description": "Coordenadas geográficas del local.",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "description": "Latitud.",
+                "example": -33.4489
+              },
+              "lng": {
+                "type": "number",
+                "description": "Longitud.",
+                "example": -70.6693
+              }
+            }
+          }
+        }
+      },
+      "apiStoreSchedule": {
+        "type": "object",
+        "description": "Horario de atención del local.",
+        "properties": {
+          "closedUntilDate": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha hasta la que el local está cerrado temporalmente. Si es null, no hay cierre temporal activo."
+          },
+          "openPeriods": {
+            "type": "array",
+            "description": "Bloques horarios en que el local atiende.",
+            "items": {
+              "$ref": "#/components/schemas/apiStoreSchedulePeriod"
+            }
+          },
+          "closedDays": {
+            "type": "array",
+            "description": "Días completos en que el local está cerrado.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "apiStoreSchedulePeriod": {
+        "type": "object",
+        "description": "Bloque horario de atención del local.",
+        "properties": {
+          "daysOfWeek": {
+            "type": "array",
+            "description": "Días de la semana en que aplica el bloque horario.",
+            "items": {
+              "type": "number"
+            }
+          },
+          "fromMinute": {
+            "type": "number",
+            "description": "Minuto del día en que comienza el bloque."
+          },
+          "toMinute": {
+            "type": "number",
+            "description": "Minuto del día en que termina el bloque."
           }
         }
       },

--- a/docs/main/openapi.json
+++ b/docs/main/openapi.json
@@ -2123,6 +2123,2495 @@
         }
       }
     },
+    "/adapters/product-outage-mcd-v1/stores/{storeId}": {
+      "post": {
+        "summary": "MCD product outage adapter v1",
+        "description": "Actualiza la disponibilidad temporal de productos u opciones MCD para un local específico. Status 2 los marca como agotados indefinidamente; status 1 los deja disponibles.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo del local donde se actualizará la disponibilidad."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apiMcdProductOutagePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiMcdProductOutageAdapterResult"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/adapters/menu-put-mcd-v1/stores/{storeId}": {
+      "put": {
+        "summary": "MCD menu adapter v1",
+        "description": "Carga un menú MCD para un local específico. Crea un precio/menú asociado al local, usa externalIds con prefijo storeId y desactiva productos/opciones ausentes solo para ese local.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo del local que recibirá el menú."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apiMcdMenuPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiMcdMenuAdapterResult"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/categories": {
+      "get": {
+        "summary": "List categories",
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/apiCategory"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/categories/{categoryId}": {
+      "get": {
+        "summary": "Category",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "categoryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo de la categoría."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiCategory"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update category",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "categoryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo de la categoría."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apiCategory"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiCategory"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/products": {
+      "get": {
+        "summary": "List products",
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/apiListingProduct"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/products/{productId}": {
+      "get": {
+        "summary": "Product",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "productId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del producto."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiListingProduct"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update product",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "productId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del producto."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apiListingProduct"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiListingProduct"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/modifiers": {
+      "get": {
+        "summary": "List modifiers",
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/apiListingModifier"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/modifiers/{modifierId}": {
+      "get": {
+        "summary": "Modifier",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "modifierId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del modificador."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiListingModifier"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update modifier",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "modifierId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del modificador."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apiListingModifier"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiListingModifier"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/modifier-options": {
+      "get": {
+        "summary": "List modifier options",
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/apiModifierOption"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/modifier-options/{modifierOptionId}": {
+      "get": {
+        "summary": "Modifier option",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "modifierOptionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo de la opción de modificador."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiModifierOption"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update modifier option",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "modifierOptionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo de la opción de modificador."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apiModifierOption"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiModifierOption"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/prices": {
+      "get": {
+        "summary": "List prices",
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/apiPrice"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/prices/{priceId}": {
+      "get": {
+        "summary": "Price",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "priceId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del precio."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiPrice"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update price",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "priceId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del precio."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apiPrice"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiPrice"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/menu": {
+      "get": {
+        "summary": "List menus",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filterEmptyModifiers",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Si es true, excluye modificadores y opciones que no estén disponibles para el menú."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/apiMenuV22Payload"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/menu/{menuId}": {
+      "head": {
+        "summary": "Menu exists",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "menuId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del menú."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiMenuV22MutationResult"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "Menu",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "menuId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del menú."
+          },
+          {
+            "in": "query",
+            "name": "filterEmptyModifiers",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Si es true, excluye modificadores y opciones que no estén disponibles para el menú."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiMenuV22Payload"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create menu",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "menuId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del menú."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/apiMenuV22Payload"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiMenuV22MutationResult"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update menu",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "menuId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del menú."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "removeItemsNotIncluded": {
+                    "type": "boolean",
+                    "description": "Si es true, desactiva productos y opciones que no vengan en el payload."
+                  },
+                  "data": {
+                    "$ref": "#/components/schemas/apiMenuV22Payload"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiMenuV22MutationResult"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Partially update menu",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "menuId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del menú."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/apiMenuV22Payload"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiMenuV22MutationResult"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/orders": {
+      "get": {
+        "summary": "List orders",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Un texto que se usa para filtrar por código de pedido o nombre del comprador."
+            }
+          },
+          {
+            "in": "query",
+            "name": "storesIds",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Un arreglo con el ID o ID externo de los locales."
+            }
+          },
+          {
+            "in": "query",
+            "name": "fromDate",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Incluir pedidos desde alguna fecha."
+            }
+          },
+          {
+            "in": "query",
+            "name": "toDate",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Incluir pedidos hasta alguna fecha."
+            }
+          },
+          {
+            "in": "query",
+            "name": "orderStatuses",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "waiting",
+                  "preparing",
+                  "delivering",
+                  "done",
+                  "cancelled",
+                  "scheduled"
+                ]
+              },
+              "description": "Muestra los pedidos que tengan estos estados."
+            }
+          },
+          {
+            "in": "query",
+            "name": "useDeliverAt",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Si es verdadero, ordena y filtra los pedidos por fecha de entrega. Si es falso, usa fecha de creación."
+            }
+          },
+          {
+            "in": "query",
+            "name": "includeNotPaid",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Si es verdadero, incluye pedidos con pago no completado (paymentStatus distinto de done)."
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "example": 1,
+              "description": "Número de página."
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "example": 10,
+              "description": "Número de items por página. Max 100. Por defecto: 10."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/apiOrder"
+                          },
+                          "description": "Items de la lista."
+                        },
+                        "hasNextPage": {
+                          "type": "boolean",
+                          "description": "Indica si hay una página siguiente."
+                        },
+                        "hasPreviousPage": {
+                          "type": "boolean",
+                          "description": "Indica si hay una página anterior."
+                        },
+                        "totalPages": {
+                          "type": "number",
+                          "description": "Total de páginas."
+                        },
+                        "totalCount": {
+                          "type": "number",
+                          "description": "Total de items."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/orders/{orderId}": {
+      "get": {
+        "summary": "Order",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "orderId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo del pedido."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiOrder"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/orders/{orderId}/accept": {
+      "post": {
+        "summary": "Accept order",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "orderId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo del pedido."
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "deliverAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Fecha comprometida de entrega. Si se omite, Justo mantiene la fecha calculada para el pedido."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiOrder"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/orders/{orderId}/reject": {
+      "post": {
+        "summary": "Reject order",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "orderId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo del pedido."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "reasonMessage"
+                ],
+                "properties": {
+                  "reasonMessage": {
+                    "type": "string",
+                    "description": "Mensaje de rechazo que verá el cliente. Debe explicar por qué no se puede preparar el pedido.",
+                    "example": "No contamos con stock suficiente para preparar el pedido."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiOrder"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/orders/{orderId}/preparation-ready": {
+      "post": {
+        "summary": "Mark order as prepared",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "orderId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo del pedido."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiOrder"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/stores/{storeId}/products/{productId}/out-of-stock": {
+      "post": {
+        "summary": "Set product out of stock",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del local."
+          },
+          {
+            "in": "path",
+            "name": "productId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del producto."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "outOfStock"
+                ],
+                "properties": {
+                  "outOfStock": {
+                    "type": "boolean",
+                    "description": "Si es verdadero, marca el producto como agotado. Si es falso, lo vuelve a dejar disponible."
+                  },
+                  "until": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "tomorrow"
+                    ],
+                    "description": "Duración predefinida del bloqueo. Usa tomorrow para agotarlo hasta el cierre del día siguiente."
+                  },
+                  "untilDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Fecha hasta la que el producto permanecerá agotado."
+                  },
+                  "stock": {
+                    "type": "number",
+                    "description": "Stock disponible. Cuando se consume en pedidos, el producto queda agotado al llegar a 0."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiProductOutOfStock"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/stores": {
+      "get": {
+        "summary": "List stores",
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/apiStore"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/stores/{storeId}": {
+      "get": {
+        "summary": "Store",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del local."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiStore"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/stores/{storeId}/temporary-close": {
+      "post": {
+        "summary": "Temporarily close store",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del local."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "closedUntilDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Fecha hasta la que el local estará cerrado. Si se envía null o se omite, se elimina el cierre temporal."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiStore"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ecommerce/stores/{storeId}/current-preparation-duration": {
+      "post": {
+        "summary": "Update current preparation duration",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "storeId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID Justo o ID externo del local."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "currentPreparationDuration"
+                ],
+                "properties": {
+                  "currentPreparationDuration": {
+                    "type": "number",
+                    "description": "Tiempo de preparación en minutos.",
+                    "example": 10
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/apiStore"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": "false"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "example": "error"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "The request has an error"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/reservations/reservation": {
       "post": {
         "summary": "Crear reserva",
@@ -4390,16 +6879,7 @@
           "countryCode": {
             "type": "string",
             "description": "Código de país ISO 3166-1 alpha-2",
-            "example": "CL",
-            "enum": [
-              "CL",
-              "MX",
-              "PE",
-              "CO",
-              "EC",
-              "CR",
-              "AR"
-            ]
+            "example": "CL"
           },
           "createdAt": {
             "type": "string",
@@ -5173,7 +7653,8 @@
             "enum": [
               "product",
               "deliveryFee",
-              "serviceFee"
+              "serviceFee",
+              "billingItem"
             ],
             "description": "Tipo de item."
           },
@@ -5192,6 +7673,16 @@
             "type": "string",
             "example": "Juan",
             "description": "Nombre del cliente que agregó el item."
+          },
+          "addedByUserId": {
+            "type": "string",
+            "example": "a3W2hiuGGLi4eECFa",
+            "description": "El ID del garzón que digitó el item."
+          },
+          "addedByUserName": {
+            "type": "string",
+            "example": "Juan",
+            "description": "Nombre del garzón que digitó el item."
           },
           "eaterLabels": {
             "type": "array",
@@ -5767,13 +8258,13 @@
               "countryCode": {
                 "type": "string",
                 "enum": [
+                  "AR",
                   "CL",
-                  "MX",
-                  "PE",
                   "CO",
-                  "EC",
                   "CR",
-                  "AR"
+                  "EC",
+                  "MX",
+                  "PE"
                 ],
                 "example": "CL"
               },
@@ -5805,6 +8296,1450 @@
                 }
               }
             }
+          }
+        }
+      },
+      "apiMcdMenuPayload": {
+        "type": "object",
+        "description": "Payload de menú MCD compatible con menu-put-mcd-v1.",
+        "additionalProperties": true,
+        "required": [
+          "menus",
+          "categories",
+          "items",
+          "modifier_groups"
+        ],
+        "properties": {
+          "menus": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "modifier_groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "apiMcdMenuAdapterResult": {
+        "type": "object",
+        "description": "Resultado de la carga del menú MCD.",
+        "properties": {
+          "adapter": {
+            "type": "string",
+            "enum": [
+              "menu-put-mcd-v1"
+            ]
+          },
+          "storeId": {
+            "type": "string"
+          },
+          "menus": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "menuId": {
+                  "type": "string"
+                },
+                "method": {
+                  "type": "string",
+                  "enum": [
+                    "POST",
+                    "PUT"
+                  ]
+                },
+                "categories": {
+                  "type": "number"
+                },
+                "products": {
+                  "type": "number"
+                },
+                "modifiers": {
+                  "type": "number"
+                },
+                "options": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      },
+      "apiMcdProductOutagePayload": {
+        "type": "object",
+        "description": "Payload MCD para marcar productos u opciones como agotados o disponibles.",
+        "additionalProperties": false,
+        "required": [
+          "app_item_ids",
+          "status"
+        ],
+        "properties": {
+          "app_item_ids": {
+            "type": "array",
+            "description": "IDs originales de McDonald’s. Justo los resuelve como {storeId}:{app_item_id}.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "number",
+            "enum": [
+              1,
+              2
+            ],
+            "description": "1 marca los items como disponibles. 2 los marca como agotados indefinidamente."
+          }
+        }
+      },
+      "apiMcdProductOutageAdapterResult": {
+        "type": "object",
+        "description": "Resultado de la actualización de disponibilidad MCD.",
+        "properties": {
+          "adapter": {
+            "type": "string",
+            "enum": [
+              "product-outage-mcd-v1"
+            ]
+          },
+          "storeId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "number",
+            "enum": [
+              1,
+              2
+            ]
+          },
+          "outOfStock": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "appItemId": {
+                  "type": "string"
+                },
+                "externalId": {
+                  "type": "string"
+                },
+                "outOfStock": {
+                  "type": "boolean"
+                },
+                "productIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "modifierOptionIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "outOfStockItemIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "appItemId": {
+                  "type": "string"
+                },
+                "externalId": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "apiCategory": {
+        "type": "object",
+        "description": "Categoría de productos.",
+        "properties": {
+          "categoryId": {
+            "type": "string",
+            "description": "ID Justo de la categoría."
+          },
+          "importId": {
+            "type": "string",
+            "description": "ID de importación de la categoría."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre de la categoría."
+          },
+          "index": {
+            "type": "number",
+            "description": "Posición de ordenamiento."
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          }
+        }
+      },
+      "apiListingProduct": {
+        "type": "object",
+        "description": "Producto del catálogo.",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "description": "ID Justo del producto."
+          },
+          "importId": {
+            "type": "string",
+            "description": "ID de importación del producto."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del producto."
+          },
+          "internalName": {
+            "type": "string",
+            "description": "Nombre interno del producto."
+          },
+          "description": {
+            "type": "string",
+            "description": "Descripción visible del producto."
+          },
+          "url": {
+            "type": "string",
+            "description": "URL pública del producto."
+          },
+          "partialUrl": {
+            "type": "string",
+            "description": "Path público del producto."
+          },
+          "categoriesNames": {
+            "type": "array",
+            "description": "Nombres de categorías asociadas.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "categoriesIds": {
+            "type": "array",
+            "description": "IDs de categorías asociadas.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "modifiersIds": {
+            "type": "array",
+            "description": "IDs de modificadores asociados.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          },
+          "images": {
+            "type": "array",
+            "description": "URLs de imágenes del producto.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "menus": {
+            "type": "array",
+            "description": "Precio y disponibilidad por precio/menú.",
+            "items": {
+              "type": "object",
+              "description": "Precio y disponibilidad del item para un precio/menú.",
+              "properties": {
+                "menuId": {
+                  "type": "string",
+                  "description": "ID Justo del precio/menú."
+                },
+                "price": {
+                  "type": "number",
+                  "description": "Precio configurado para este precio/menú."
+                },
+                "basePrice": {
+                  "type": "number",
+                  "description": "Precio base configurado para este precio/menú."
+                },
+                "discount": {
+                  "type": "number",
+                  "description": "Descuento principal configurado."
+                },
+                "discounts": {
+                  "type": "array",
+                  "description": "Descuentos configurados.",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "available": {
+                  "type": "boolean",
+                  "description": "Indica si el item está disponible."
+                },
+                "externalId": {
+                  "type": "string",
+                  "description": "ID externo efectivo para este precio/menú, si fue reemplazado."
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Metadata del precio/disponibilidad escrita por API v3.",
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "apiListingModifier": {
+        "type": "object",
+        "description": "Modificador del catálogo.",
+        "properties": {
+          "modifierId": {
+            "type": "string",
+            "description": "ID Justo del modificador."
+          },
+          "importId": {
+            "type": "string",
+            "description": "ID de importación del modificador."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del modificador."
+          },
+          "description": {
+            "type": "string",
+            "description": "Descripción del modificador."
+          },
+          "shortName": {
+            "type": "string",
+            "description": "Nombre corto del modificador."
+          },
+          "internalName": {
+            "type": "string",
+            "description": "Nombre interno del modificador."
+          },
+          "min": {
+            "type": "number",
+            "description": "Cantidad mínima de opciones."
+          },
+          "max": {
+            "type": "number",
+            "description": "Cantidad máxima de opciones."
+          },
+          "optional": {
+            "type": "boolean",
+            "description": "Indica si el modificador es opcional."
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          },
+          "optionIds": {
+            "type": "array",
+            "description": "IDs de opciones asociadas.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "options": {
+            "type": "array",
+            "description": "Opciones asociadas al modificador.",
+            "items": {
+              "$ref": "#/components/schemas/apiModifierOption"
+            }
+          }
+        }
+      },
+      "apiModifierOption": {
+        "type": "object",
+        "description": "Opción de modificador.",
+        "properties": {
+          "optionId": {
+            "type": "string",
+            "description": "ID Justo de la opción."
+          },
+          "importId": {
+            "type": "string",
+            "description": "ID de importación de la opción."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre de la opción."
+          },
+          "internalName": {
+            "type": "string",
+            "description": "Nombre interno de la opción."
+          },
+          "max": {
+            "type": "number",
+            "description": "Cantidad máxima seleccionable."
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          },
+          "menus": {
+            "type": "array",
+            "description": "Precio y disponibilidad por precio/menú.",
+            "items": {
+              "type": "object",
+              "description": "Precio y disponibilidad del item para un precio/menú.",
+              "properties": {
+                "menuId": {
+                  "type": "string",
+                  "description": "ID Justo del precio/menú."
+                },
+                "price": {
+                  "type": "number",
+                  "description": "Precio configurado para este precio/menú."
+                },
+                "basePrice": {
+                  "type": "number",
+                  "description": "Precio base configurado para este precio/menú."
+                },
+                "discount": {
+                  "type": "number",
+                  "description": "Descuento principal configurado."
+                },
+                "discounts": {
+                  "type": "array",
+                  "description": "Descuentos configurados.",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "available": {
+                  "type": "boolean",
+                  "description": "Indica si el item está disponible."
+                },
+                "externalId": {
+                  "type": "string",
+                  "description": "ID externo efectivo para este precio/menú, si fue reemplazado."
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Metadata del precio/disponibilidad escrita por API v3.",
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "apiPrice": {
+        "type": "object",
+        "description": "Precio/menú interno de Justo.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID Justo del precio."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del precio."
+          },
+          "priority": {
+            "type": "number",
+            "description": "Prioridad de aplicación."
+          },
+          "storesIds": {
+            "type": "array",
+            "description": "Locales asociados.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "channels": {
+            "type": "array",
+            "description": "Canales asociados.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "daysBefore": {
+            "type": "number",
+            "description": "Días de anticipación permitidos."
+          },
+          "schedule": {
+            "type": "object",
+            "description": "Horario de disponibilidad del precio.",
+            "additionalProperties": true
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo configurado por la marca."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del item escrita por API v3.",
+            "additionalProperties": true
+          }
+        }
+      },
+      "apiMenuV22Payload": {
+        "type": "object",
+        "description": "Payload de menú compatible con API v2.2. Incluye menu, products, options, modifiers y categories. En API v3 los objetos menu, products, options, modifiers y categories aceptan metadata. Products y options aceptan priceMetadata para guardar metadata del precio/disponibilidad del menú.",
+        "additionalProperties": true
+      },
+      "apiMenuV22MutationResult": {
+        "type": "object",
+        "description": "Resultado de una escritura de menú compatible con API v2.2.",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "description": "Errores no bloqueantes encontrados al procesar productos u opciones.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "apiOrder": {
+        "type": "object",
+        "description": "Pedido de ecommerce.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID del pedido.",
+            "example": "ord-123"
+          },
+          "orderStatus": {
+            "type": "string",
+            "description": "Estado operacional del pedido.",
+            "enum": [
+              "pending",
+              "waiting",
+              "preparing",
+              "delivering",
+              "done",
+              "cancelled"
+            ]
+          },
+          "paymentStatus": {
+            "type": "string",
+            "description": "Estado del pago del pedido.",
+            "enum": [
+              "pending",
+              "done",
+              "error",
+              "blocked",
+              "inReview",
+              "waitingForAdditionalPayment"
+            ]
+          },
+          "isScheduled": {
+            "type": "boolean",
+            "description": "Indica si el pedido es programado."
+          },
+          "isConfirmed": {
+            "type": "boolean",
+            "description": "Indica si el pedido programado fue confirmado."
+          },
+          "websiteId": {
+            "type": "string",
+            "description": "ID de la marca."
+          },
+          "storeId": {
+            "type": "string",
+            "description": "ID del local."
+          },
+          "code": {
+            "type": "string",
+            "description": "Código único del pedido en Justo.",
+            "example": "123"
+          },
+          "fullCode": {
+            "type": "string",
+            "description": "Código del pedido con el correlativo diario de la marca.",
+            "example": "C#123"
+          },
+          "userId": {
+            "type": "string",
+            "description": "ID del usuario que creó el pedido."
+          },
+          "createdAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha de creación del pedido."
+          },
+          "address": {
+            "$ref": "#/components/schemas/apiOrderAddress"
+          },
+          "menuId": {
+            "type": "string",
+            "description": "ID del menú desde el que se creó el pedido."
+          },
+          "deliveryType": {
+            "type": "string",
+            "description": "Tipo de entrega del pedido.",
+            "enum": [
+              "delivery",
+              "go",
+              "serve"
+            ]
+          },
+          "deliverAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha en que el pedido debe ser entregado o retirado."
+          },
+          "timeText": {
+            "type": "string",
+            "description": "Texto legible con la ventana estimada de entrega."
+          },
+          "paymentType": {
+            "type": "string",
+            "description": "Medio de pago seleccionado."
+          },
+          "paymentTypeLabel": {
+            "type": "string",
+            "description": "Nombre legible del medio de pago."
+          },
+          "paymentTypeIsIntegration": {
+            "type": "boolean",
+            "description": "Indica si el medio de pago viene de una integración."
+          },
+          "tipAmount": {
+            "type": "number",
+            "description": "Monto de propina."
+          },
+          "amountToPay": {
+            "type": "number",
+            "description": "Monto total a pagar por el cliente, incluyendo propina."
+          },
+          "deliveryFee": {
+            "type": "number",
+            "description": "Precio del despacho cobrado al cliente."
+          },
+          "serviceFee": {
+            "type": "number",
+            "description": "Cargo de servicio cobrado al cliente."
+          },
+          "itemsPrice": {
+            "type": "number",
+            "description": "Precio de los productos, sin propina ni despacho."
+          },
+          "totalPrice": {
+            "type": "number",
+            "description": "Monto del pedido sin propina."
+          },
+          "totalDiscount": {
+            "type": "number",
+            "description": "Monto total descontado del pedido."
+          },
+          "expectedPreparationDuration": {
+            "type": "number",
+            "description": "Tiempo estimado de preparación en minutos."
+          },
+          "deliveryDuration": {
+            "type": "number",
+            "description": "Tiempo estimado de despacho en minutos."
+          },
+          "cashAmount": {
+            "type": "number",
+            "description": "Monto que el cliente declara pagar si el medio de pago es efectivo."
+          },
+          "source": {
+            "type": "string",
+            "description": "Origen del pedido."
+          },
+          "buyerName": {
+            "type": "string",
+            "description": "Nombre del cliente."
+          },
+          "phone": {
+            "type": "string",
+            "description": "Teléfono del cliente."
+          },
+          "email": {
+            "type": "string",
+            "description": "Email del cliente."
+          },
+          "couponId": {
+            "type": "string",
+            "description": "ID del cupón usado."
+          },
+          "couponName": {
+            "type": "string",
+            "description": "Nombre del cupón usado."
+          },
+          "couponCode": {
+            "type": "string",
+            "description": "Código del cupón usado."
+          },
+          "couponDiscount": {
+            "type": "number",
+            "description": "Monto descontado por cupón."
+          },
+          "flagColor": {
+            "type": "string",
+            "description": "Color de la bandera del pedido en POS."
+          },
+          "items": {
+            "type": "array",
+            "description": "Detalle de los productos vendidos en el pedido.",
+            "items": {
+              "$ref": "#/components/schemas/apiOrderItem"
+            }
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/apiOrderTransaction"
+          },
+          "deliveries": {
+            "type": "array",
+            "description": "Despachos asociados al pedido.",
+            "items": {
+              "$ref": "#/components/schemas/apiOrderDelivery"
+            }
+          },
+          "orderParams": {
+            "type": "object",
+            "description": "Parámetros adicionales del pedido.",
+            "additionalProperties": true
+          },
+          "hasManagedDelivery": {
+            "type": "boolean",
+            "description": "Indica si el despacho es gestionado por Justo."
+          },
+          "gift": {
+            "type": "object",
+            "description": "Información de regalo, si el pedido fue marcado como regalo.",
+            "additionalProperties": true
+          },
+          "billing": {
+            "type": "object",
+            "description": "Información de facturación del cliente.",
+            "additionalProperties": true
+          },
+          "cancellationInfo": {
+            "type": "object",
+            "description": "Información de cancelación del pedido.",
+            "additionalProperties": true
+          },
+          "deliveryZoneName": {
+            "type": "string",
+            "description": "Nombre de la zona de despacho aplicada al pedido."
+          }
+        }
+      },
+      "apiOrderAddress": {
+        "type": "object",
+        "description": "Dirección de entrega del pedido.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID de la dirección."
+          },
+          "placeId": {
+            "type": "string",
+            "description": "ID del lugar asociado a la dirección."
+          },
+          "address": {
+            "type": "string",
+            "description": "Dirección principal en formato legacy.",
+            "example": "Av. Apoquindo 3000"
+          },
+          "addressLine2": {
+            "type": "string",
+            "description": "Departamento, oficina u otra información complementaria.",
+            "example": "Depto 1201"
+          },
+          "addressSecondary": {
+            "type": "string",
+            "description": "Comuna, ciudad o referencia secundaria de la dirección."
+          },
+          "location": {
+            "type": "object",
+            "description": "Coordenadas geográficas.",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "description": "Latitud.",
+                "example": -33.4489
+              },
+              "lng": {
+                "type": "number",
+                "description": "Longitud.",
+                "example": -70.6693
+              }
+            }
+          }
+        }
+      },
+      "apiOrderDelivery": {
+        "type": "object",
+        "description": "Información de un despacho asociado al pedido.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID del despacho."
+          },
+          "price": {
+            "type": "number",
+            "description": "Precio del despacho.",
+            "example": 2500
+          },
+          "status": {
+            "type": "string",
+            "description": "Estado del despacho.",
+            "enum": [
+              "active",
+              "canceled",
+              "cancelled",
+              "done",
+              "error",
+              "pending",
+              "scheduled",
+              "delivering",
+              "waiting",
+              "unconfirmed"
+            ]
+          },
+          "placeName": {
+            "type": "string",
+            "description": "Nombre del lugar de destino."
+          },
+          "isCash": {
+            "type": "boolean",
+            "description": "Indica si el despacho se paga en efectivo."
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Instrucciones para el despacho."
+          },
+          "fromLocation": {
+            "type": "object",
+            "description": "Coordenadas geográficas.",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "description": "Latitud.",
+                "example": -33.4489
+              },
+              "lng": {
+                "type": "number",
+                "description": "Longitud.",
+                "example": -70.6693
+              }
+            }
+          },
+          "toLocation": {
+            "type": "object",
+            "description": "Coordenadas geográficas.",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "description": "Latitud.",
+                "example": -33.4489
+              },
+              "lng": {
+                "type": "number",
+                "description": "Longitud.",
+                "example": -70.6693
+              }
+            }
+          },
+          "trackingURL": {
+            "type": "string",
+            "description": "URL de seguimiento del despacho."
+          },
+          "orderId": {
+            "type": "string",
+            "description": "ID del pedido asociado al despacho."
+          },
+          "activatesAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha en que se activa el despacho."
+          },
+          "createdAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha de creación del despacho."
+          },
+          "forDate": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha objetivo del despacho."
+          },
+          "pickupAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha de retiro del pedido."
+          },
+          "completedAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha en que se completó el despacho."
+          },
+          "canceledAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha de cancelación del despacho."
+          },
+          "deliveryExpectedAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha estimada de entrega."
+          },
+          "driverReceivedAt": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha en que el driver recibió el pedido, si aplica."
+          },
+          "driverInformation": {
+            "type": "object",
+            "description": "Información del driver asignado, si está disponible.",
+            "additionalProperties": true
+          },
+          "deliveryInformation": {
+            "type": "object",
+            "description": "Información adicional del despacho, si está disponible.",
+            "additionalProperties": true
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo del despacho, si existe."
+          },
+          "specialCode": {
+            "type": "string",
+            "description": "Código externo o especial del despacho, si existe."
+          }
+        }
+      },
+      "apiOrderDeliveryUpdatedWebhookData": {
+        "type": "object",
+        "description": "Datos del webhook de actualización de despacho de pedido.",
+        "properties": {
+          "order": {
+            "$ref": "#/components/schemas/apiOrder"
+          },
+          "delivery": {
+            "$ref": "#/components/schemas/apiOrderDelivery"
+          }
+        }
+      },
+      "apiOrderItem": {
+        "type": "object",
+        "description": "Producto vendido dentro del pedido.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID del item del pedido."
+          },
+          "product": {
+            "type": "object",
+            "description": "Producto asociado al item.",
+            "properties": {
+              "_id": {
+                "type": "string",
+                "description": "ID Justo del producto."
+              },
+              "name": {
+                "type": "string",
+                "description": "Nombre del producto.",
+                "example": "Hamburguesa"
+              },
+              "externalId": {
+                "type": "string",
+                "description": "ID externo del producto configurado por la marca."
+              },
+              "metadata": {
+                "type": "object",
+                "description": "Metadata del producto escrita por API v3.",
+                "additionalProperties": true
+              },
+              "priceMetadata": {
+                "type": "object",
+                "description": "Metadata del precio/disponibilidad escrita por API v3.",
+                "additionalProperties": true
+              }
+            }
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Precio unitario con descuento, sin incluir descuento de cupón.",
+            "example": 5990
+          },
+          "baseUnitPrice": {
+            "type": "number",
+            "description": "Precio unitario original antes de descuentos.",
+            "example": 5990
+          },
+          "productPrice": {
+            "type": "number",
+            "description": "Precio del producto con descuento.",
+            "example": 5990
+          },
+          "baseProductPrice": {
+            "type": "number",
+            "description": "Precio original del producto antes de descuentos.",
+            "example": 5990
+          },
+          "amount": {
+            "type": "number",
+            "description": "Cantidad de este producto en el pedido.",
+            "example": 2
+          },
+          "comment": {
+            "type": "string",
+            "description": "Instrucciones adicionales para este producto."
+          },
+          "description": {
+            "type": "string",
+            "description": "Resumen en texto de los modificadores e instrucciones del item.",
+            "example": "Bebida: Coca Zero - Comentario: \"Sin cebolla\""
+          },
+          "promotionId": {
+            "type": "string",
+            "description": "ID de la promoción aplicada al item."
+          },
+          "promotionDiscount": {
+            "type": "number",
+            "description": "Monto descontado por promoción en el item."
+          },
+          "promotionType": {
+            "type": "string",
+            "description": "Tipo de promoción aplicada al item."
+          },
+          "promotionLabel": {
+            "type": "string",
+            "description": "Etiqueta visible de la promoción aplicada al item."
+          },
+          "modifiers": {
+            "type": "array",
+            "description": "Modificadores seleccionados para el item.",
+            "items": {
+              "$ref": "#/components/schemas/apiOrderItemModifier"
+            }
+          }
+        }
+      },
+      "apiOrderItemModifier": {
+        "type": "object",
+        "description": "Modificador seleccionado para un item del pedido.",
+        "properties": {
+          "modifierId": {
+            "type": "string",
+            "description": "ID Justo del modificador."
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo del modificador configurado por la marca."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del modificador.",
+            "example": "Agregados"
+          },
+          "shortName": {
+            "type": "string",
+            "description": "Nombre corto del modificador."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata del modificador escrita por API v3.",
+            "additionalProperties": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Resumen en texto de las opciones seleccionadas."
+          },
+          "countById": {
+            "type": "object",
+            "description": "Cantidad seleccionada por ID Justo de opción.",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "countByExternalId": {
+            "type": "object",
+            "description": "Cantidad seleccionada por ID externo de opción.",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "options": {
+            "type": "array",
+            "description": "Opciones seleccionadas para este modificador.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "optionId": {
+                  "type": "string",
+                  "description": "ID Justo de la opción."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Nombre de la opción.",
+                  "example": "Queso"
+                },
+                "price": {
+                  "type": "number",
+                  "description": "Precio pagado por la opción.",
+                  "example": 1000
+                },
+                "externalId": {
+                  "type": "string",
+                  "description": "ID externo de la opción configurado por la marca."
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Metadata de la opción escrita por API v3.",
+                  "additionalProperties": true
+                },
+                "priceMetadata": {
+                  "type": "object",
+                  "description": "Metadata del precio/disponibilidad escrita por API v3.",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "apiOrderStatusUpdatedWebhookData": {
+        "type": "object",
+        "description": "Datos del webhook de cambio de estado de pedido.",
+        "properties": {
+          "order": {
+            "$ref": "#/components/schemas/apiOrder"
+          },
+          "previousOrderStatus": {
+            "type": "string",
+            "description": "Estado anterior del pedido.",
+            "enum": [
+              "pending",
+              "waiting",
+              "preparing",
+              "delivering",
+              "done",
+              "cancelled"
+            ]
+          },
+          "newOrderStatus": {
+            "type": "string",
+            "description": "Nuevo estado del pedido.",
+            "enum": [
+              "pending",
+              "waiting",
+              "preparing",
+              "delivering",
+              "done",
+              "cancelled"
+            ]
+          }
+        }
+      },
+      "apiOrderTransaction": {
+        "type": "object",
+        "description": "Transacción de pago asociada al pedido.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID de la transacción."
+          },
+          "totalPrice": {
+            "type": "number",
+            "description": "Monto total de la transacción."
+          },
+          "paymentType": {
+            "type": "string",
+            "description": "Medio de pago usado en la transacción."
+          },
+          "cardType": {
+            "type": "string",
+            "description": "Tipo de tarjeta usada, si aplica."
+          },
+          "cardLast4": {
+            "type": "string",
+            "description": "Últimos cuatro dígitos de la tarjeta, si aplica."
+          },
+          "status": {
+            "type": "string",
+            "description": "Estado de la transacción."
+          }
+        }
+      },
+      "apiProductOutOfStock": {
+        "type": "object",
+        "description": "Estado de disponibilidad de un producto en un local.",
+        "properties": {
+          "storeId": {
+            "type": "string",
+            "description": "ID Justo del local."
+          },
+          "productId": {
+            "type": "string",
+            "description": "ID Justo del producto."
+          },
+          "productExternalId": {
+            "type": "string",
+            "description": "ID externo del producto configurado por la marca."
+          },
+          "outOfStock": {
+            "type": "boolean",
+            "description": "Indica si el producto quedó marcado como agotado en el local."
+          },
+          "outOfStockItemId": {
+            "type": "string",
+            "description": "ID del registro de producto agotado creado por Justo."
+          },
+          "until": {
+            "type": "string",
+            "enum": [
+              "none",
+              "tomorrow"
+            ],
+            "description": "Duración predefinida del bloqueo de stock."
+          },
+          "untilDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Fecha hasta la que el producto permanecerá agotado."
+          },
+          "stock": {
+            "type": "number",
+            "description": "Stock disponible configurado para el producto."
+          }
+        }
+      },
+      "apiStore": {
+        "type": "object",
+        "description": "Local de una marca.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID Justo del local."
+          },
+          "websiteId": {
+            "type": "string",
+            "description": "ID de la marca a la que pertenece el local."
+          },
+          "name": {
+            "type": "string",
+            "description": "Nombre del local.",
+            "example": "Providencia"
+          },
+          "acceptDelivery": {
+            "type": "boolean",
+            "description": "Indica si el local acepta pedidos con despacho."
+          },
+          "acceptServe": {
+            "type": "boolean",
+            "description": "Indica si el local acepta pedidos para servir en mesa."
+          },
+          "acceptGo": {
+            "type": "boolean",
+            "description": "Indica si el local acepta pedidos para retiro."
+          },
+          "currentPreparationDuration": {
+            "type": "number",
+            "description": "Tiempo actual de preparación en minutos."
+          },
+          "currentDeliveryDuration": {
+            "type": "number",
+            "description": "Tiempo actual estimado de despacho en minutos."
+          },
+          "phone": {
+            "type": "string",
+            "description": "Teléfono del local."
+          },
+          "address": {
+            "$ref": "#/components/schemas/apiStoreAddress"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "ID externo del local configurado por la marca."
+          },
+          "schedule": {
+            "$ref": "#/components/schemas/apiStoreSchedule"
+          }
+        }
+      },
+      "apiStoreAddress": {
+        "type": "object",
+        "description": "Dirección del local.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "ID de la dirección."
+          },
+          "placeId": {
+            "type": "string",
+            "description": "ID del lugar asociado a la dirección."
+          },
+          "address": {
+            "type": "string",
+            "description": "Dirección principal en formato legacy.",
+            "example": "Av. Apoquindo 3000"
+          },
+          "addressLine2": {
+            "type": "string",
+            "description": "Departamento, oficina u otra información complementaria."
+          },
+          "addressSecondary": {
+            "type": "string",
+            "description": "Comuna, ciudad o referencia secundaria de la dirección."
+          },
+          "streetAddress": {
+            "type": "string",
+            "description": "Calle y número normalizados."
+          },
+          "extendedAddress": {
+            "type": "string",
+            "description": "Información complementaria normalizada."
+          },
+          "locality": {
+            "type": "string",
+            "description": "Comuna o localidad."
+          },
+          "region": {
+            "type": "string",
+            "description": "Región o estado."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Código postal."
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "Código de país ISO 3166-1 alpha-2."
+          },
+          "countryName": {
+            "type": "string",
+            "description": "Nombre del país."
+          },
+          "location": {
+            "type": "object",
+            "description": "Coordenadas geográficas del local.",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "description": "Latitud.",
+                "example": -33.4489
+              },
+              "lng": {
+                "type": "number",
+                "description": "Longitud.",
+                "example": -70.6693
+              }
+            }
+          }
+        }
+      },
+      "apiStoreSchedule": {
+        "type": "object",
+        "description": "Horario de atención del local.",
+        "properties": {
+          "closedUntilDate": {
+            "type": "string",
+            "example": "2020-01-01T00:00:00.000Z",
+            "format": "date-time",
+            "description": "Fecha hasta la que el local está cerrado temporalmente. Si es null, no hay cierre temporal activo."
+          },
+          "openPeriods": {
+            "type": "array",
+            "description": "Bloques horarios en que el local atiende.",
+            "items": {
+              "$ref": "#/components/schemas/apiStoreSchedulePeriod"
+            }
+          },
+          "closedDays": {
+            "type": "array",
+            "description": "Días completos en que el local está cerrado.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "apiStoreSchedulePeriod": {
+        "type": "object",
+        "description": "Bloque horario de atención del local.",
+        "properties": {
+          "daysOfWeek": {
+            "type": "array",
+            "description": "Días de la semana en que aplica el bloque horario.",
+            "items": {
+              "type": "number"
+            }
+          },
+          "fromMinute": {
+            "type": "number",
+            "description": "Minuto del día en que comienza el bloque."
+          },
+          "toMinute": {
+            "type": "number",
+            "description": "Minuto del día en que termina el bloque."
           }
         }
       },

--- a/mint.json
+++ b/mint.json
@@ -57,6 +57,10 @@
 			"url": "docs/reservations"
 		},
 		{
+			"name": "Ecommerce",
+			"url": "docs/ecommerce"
+		},
+		{
 			"name": "Royalty",
 			"url": "docs/royalty"
 		},
@@ -241,6 +245,75 @@
 			"version": "v3",
 			"pages": [
 				"docs/embedded_ordering/introduction"
+			]
+		},
+		{
+			"group": "Ecommerce",
+			"version": "v3",
+			"pages": [
+				"docs/ecommerce/introduction",
+				{
+					"group": "Menú",
+					"pages": [
+						"docs/ecommerce/endpoints/menu/head-menu",
+						"docs/ecommerce/endpoints/menu/list-menus",
+						"docs/ecommerce/endpoints/menu/get-menu",
+						"docs/ecommerce/endpoints/menu/create-menu",
+						"docs/ecommerce/endpoints/menu/update-menu",
+						"docs/ecommerce/endpoints/menu/partially-update-menu"
+					]
+				},
+				{
+					"group": "Catálogo",
+					"pages": [
+						"docs/ecommerce/endpoints/catalog/list-categories",
+						"docs/ecommerce/endpoints/catalog/get-category",
+						"docs/ecommerce/endpoints/catalog/update-category",
+						"docs/ecommerce/endpoints/catalog/list-products",
+						"docs/ecommerce/endpoints/catalog/get-product",
+						"docs/ecommerce/endpoints/catalog/update-product",
+						"docs/ecommerce/endpoints/catalog/list-modifiers",
+						"docs/ecommerce/endpoints/catalog/get-modifier",
+						"docs/ecommerce/endpoints/catalog/update-modifier",
+						"docs/ecommerce/endpoints/catalog/list-modifier-options",
+						"docs/ecommerce/endpoints/catalog/get-modifier-option",
+						"docs/ecommerce/endpoints/catalog/update-modifier-option",
+						"docs/ecommerce/endpoints/catalog/list-prices",
+						"docs/ecommerce/endpoints/catalog/get-price",
+						"docs/ecommerce/endpoints/catalog/update-price"
+					]
+				},
+				{
+					"group": "Pedidos",
+					"pages": [
+						"docs/ecommerce/endpoints/orders/list-orders",
+						"docs/ecommerce/endpoints/orders/get-order",
+						"docs/ecommerce/endpoints/orders/accept-order",
+						"docs/ecommerce/endpoints/orders/reject-order",
+						"docs/ecommerce/endpoints/orders/mark-order-prepared"
+					]
+				},
+				{
+					"group": "Productos",
+					"pages": ["docs/ecommerce/endpoints/products/set-product-out-of-stock"]
+				},
+				{
+					"group": "Locales",
+					"pages": [
+						"docs/ecommerce/endpoints/stores/list-stores",
+						"docs/ecommerce/endpoints/stores/get-store",
+						"docs/ecommerce/endpoints/stores/temporary-close-store",
+						"docs/ecommerce/endpoints/stores/update-current-preparation-duration"
+					]
+				},
+				{
+					"group": "Webhooks",
+					"pages": [
+						"docs/ecommerce/webhooks/orders/created",
+						"docs/ecommerce/webhooks/orders/status-updated",
+						"docs/ecommerce/webhooks/orders/delivery-updated"
+					]
+				}
 			]
 		},
 		{


### PR DESCRIPTION
## Propósito

Documentar la nueva sección Ecommerce v3, incluyendo endpoints de pedidos, menú, catálogo, locales, productos, webhooks y adapters privados McDonald's.

## Estrategia

- Agrega páginas Mintlify para endpoints Ecommerce.
- Agrega páginas separadas para los adapters McDonald's de importación de menú y agotados.
- Actualiza navegación de Ecommerce en Mintlify.
- Regenera OpenAPI y OpenAPI Webhooks.

## Aseguramiento de calidad

- JSON de OpenAPI validado localmente.
- Rama rebasada sobre origin/main.

## Changelog

- Publica documentación Ecommerce v3 y adapters McDonald's.