### PR TITLE
Document McDonald's order adapter nullable numbers

### DIFF
--- a/docs/ecommerce/adapters/order-get-mcd-v1.mdx
+++ b/docs/ecommerce/adapters/order-get-mcd-v1.mdx
@@ -31,12 +31,13 @@ El API key debe tener permisos `admin`, pertenecer a la misma marca del pedido y
 - Después de recibir un webhook, McDonald's puede llamar este adapter con el `orderId` del webhook para consultar la orden en formato `orderNew`.
 - La llamada obtiene una orden ecommerce de Justo y la devuelve en el formato de evento `orderNew` solicitado por McDonald's.
 - El ETA que Flex Digital necesita para pasar la orden a cocina corresponde a `order_info.expected_arrived_eta`: fecha estimada de llegada del repartidor al local, en Unix timestamp segundos.
-- Justo solo envía `expected_arrived_eta` cuando existe un despacho con repartidor y se puede calcular la llegada al local. Si no hay repartidor asignado o no hay ETA calculable, se envía `0`.
+- Justo solo envía `expected_arrived_eta` cuando existe un despacho con repartidor y se puede calcular la llegada al local. Si no hay repartidor asignado o no hay ETA calculable, se envía `null`.
 - Los identificadores de orden se envían como string.
 - `app_id` se envía vacío porque Justo no lo tiene como dato propio de la orden.
 - `app_shop_id` se envía como el `storeId` de Justo.
 - Los productos y opciones usan el ID original McDonald's guardado en `metadata.id` por `menu-put-mcd-v1`. Si no existe, Justo usa el `externalId` sin el prefijo `{storeId}:`.
 - Los montos se devuelven con la misma unidad entera que expone Justo para la orden.
+- Los campos numéricos que dependen de un dato no informado por Justo se envían como `null`, no como `0`. El valor `0` solo se usa cuando Justo lo entrega explícitamente o cuando el campo es un código fijo del formato McDonald's.
 
 ## Ejemplo
 
@@ -65,31 +66,31 @@ curl -X GET \
         "order_channel": "Food",
         "remark": "",
         "country": "PE",
-        "city_id": 0,
+        "city_id": null,
         "timezone": "America/Santiago",
         "pay_type": 1,
         "pay_method": 1,
         "pay_channel": 150,
         "delivery_type": 1,
-        "delivery_eta": 0,
-        "expected_cook_eta": 0,
+        "delivery_eta": null,
+        "expected_cook_eta": null,
         "expected_arrived_eta": 1778790463,
         "create_time": 1778788575,
         "pay_time": 1778788575,
-        "complete_time": 0,
-        "cancel_time": 0,
-        "shop_confirm_time": 0,
+        "complete_time": null,
+        "cancel_time": null,
+        "shop_confirm_time": null,
         "c_cancel_preference": 7,
         "price": {
           "order_price": 6330,
           "items_discount": 4070,
-          "delivery_discount": 0,
+          "delivery_discount": null,
           "others_fees": {
             "service_price": 208
           },
-          "shop_paid_money": 0,
-          "refund_price": 0,
-          "store_charged_delivery_price": 0
+          "shop_paid_money": null,
+          "refund_price": null,
+          "store_charged_delivery_price": null
         },
         "shop": {
           "shop_id": "CRR",
@@ -98,7 +99,7 @@ curl -X GET \
           "shop_name": "McDonald's - Chorrillos",
           "shop_phone": [
             {
-              "calling_code": 0,
+              "calling_code": null,
               "phone": "976645546",
               "type": "1"
             }
@@ -137,16 +138,20 @@ curl -X GET \
 | `app_shop_id` | `order.storeId` |
 | `data.order_id` | `order._id` como string |
 | `order_info.order_id` | `order._id` como string |
-| `order_info.order_index` | `order.code` convertido a número cuando aplica |
-| `order_info.expected_arrived_eta` | `delivery.estimatedArrivalAtStoreAt` en Unix timestamp segundos cuando hay repartidor activo. Si el repartidor ya llegó al local, usa `delivery.nearStoreAt`. Si no hay repartidor o ETA calculable, envía `0`. |
-| `order_info.expected_cook_eta` | `0`. Flex Digital calcula el momento de preparación usando `expected_arrived_eta` menos su tiempo de preparación configurado. |
-| `order_info.delivery_eta` | `0`. No se usa para informar ETA de llegada del repartidor al local. |
-| `order_info.price.order_price` | `order.totalPrice - order.deliveryFee` |
-| `order_info.price.items_discount` | `order.totalDiscount` |
-| `order_info.price.others_fees.service_price` | `order.serviceFee` |
-| `order_info.price.store_charged_delivery_price` | `0` |
+| `order_info.order_index` | `order.code` convertido a número cuando aplica. Si no se puede convertir, envía `null`. |
+| `order_info.expected_arrived_eta` | `delivery.estimatedArrivalAtStoreAt` en Unix timestamp segundos cuando hay repartidor activo. Si el repartidor ya llegó al local, usa `delivery.nearStoreAt`. Si no hay repartidor o ETA calculable, envía `null`. |
+| `order_info.expected_cook_eta` | `null`. Flex Digital calcula el momento de preparación usando `expected_arrived_eta` menos su tiempo de preparación configurado. |
+| `order_info.delivery_eta` | `null`. No se usa para informar ETA de llegada del repartidor al local. |
+| `order_info.complete_time`, `order_info.cancel_time`, `order_info.shop_confirm_time` | `null` cuando Justo no entrega esos timestamps al adapter. |
+| `order_info.price.order_price` | `order.totalPrice - order.deliveryFee` cuando ambos valores existen. Si falta alguno, envía `null`. |
+| `order_info.price.items_discount` | `order.totalDiscount`. Si no existe, envía `null`. |
+| `order_info.price.others_fees.service_price` | `order.serviceFee`. Si no existe, envía `null`. |
+| `order_info.price.delivery_discount`, `order_info.price.shop_paid_money`, `order_info.price.refund_price`, `order_info.price.store_charged_delivery_price` | `null` cuando Justo no entrega esos valores al adapter. |
+| `order_info.receive_address.poi_lat`, `order_info.receive_address.poi_lng` | Coordenadas de la dirección. Si no existen, envía `null`. |
 | `order_items[].app_item_id` | `product.metadata.id` o `product.externalId` sin `{storeId}:` |
+| `order_items[].total_price`, `order_items[].sku_price`, `order_items[].real_price` | Precio Justo correspondiente. Si el valor existe y es `0`, se envía `0`; si no existe, se envía `null`. |
 | `order_items[].sub_item_list[].app_item_id` | `modifierOption.metadata.id` o `modifierOption.externalId` sin `{storeId}:` |
+| `order_items[].sub_item_list[].total_price`, `order_items[].sub_item_list[].sku_price` | Precio de la opción. Si el valor existe y es `0`, se envía `0`; si no existe, se envía `null`. |
 
 ## Códigos pendientes por confirmar
 

--- a/docs/main/openapi-webhooks.json
+++ b/docs/main/openapi-webhooks.json
@@ -4270,7 +4270,10 @@
             ]
           },
           "timestamp": {
-            "type": "number",
+            "type": [
+              "number",
+              "null"
+            ],
             "description": "Timestamp Unix en segundos de creación de la orden."
           },
           "data": {

--- a/docs/main/openapi.json
+++ b/docs/main/openapi.json
@@ -8473,7 +8473,10 @@
             ]
           },
           "timestamp": {
-            "type": "number",
+            "type": [
+              "number",
+              "null"
+            ],
             "description": "Timestamp Unix en segundos de creación de la orden."
           },
           "data": {


### PR DESCRIPTION
## Propósito

Actualizar la documentación del adapter privado de McDonald's para reflejar que los campos numéricos no informados se devuelven como `null` y no como `0`.

## Estrategia

Se actualizó la página `order-get-mcd-v1` con el nuevo comportamiento, el ejemplo de respuesta y el mapeo de campos. También se sincronizaron los archivos OpenAPI publicados.

## Aseguramiento de la calidad

- `git diff --check`
- Contrato validado contra el cambio de API en getjusto/justo-services#6397.

## Changelog

La documentación del adapter McDonald's de consulta de órdenes ahora indica que los campos numéricos ausentes se envían como `null` y que `0` queda reservado para valores reales o códigos fijos.
